### PR TITLE
Minimal changes to decouple from composer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+composer.lock
+phpcs.xml
+phpunit.xml
+vendor/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Composer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# xdebug-handler

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,39 @@
+{
+    "name": "composer/xdebug-handler",
+    "description": "Restarts a process without xdebug.",
+    "type": "library",
+    "license": "MIT",
+    "keywords": [
+        "xdebug",
+        "performance"
+    ],
+    "authors": [
+        {
+            "name": "John Stevenson",
+            "email": "john-stevenson@blueyonder.co.uk"
+        }
+    ],
+    "support": {
+        "irc": "irc://irc.freenode.org/composer",
+        "issues": "https://github.com/composer/xdebug-handler/issues"
+    },
+    "require": {
+        "php": "^5.3.2 || ^7.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.5 || ^5.0.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "Composer\\XdebugHandler\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Composer\\XdebugHandler\\": "tests"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="vendor/autoload.php"
+    >
+    <testsuites>
+        <testsuite name="XdebugHandler Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src/Composer/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -1,0 +1,350 @@
+<?php
+
+/*
+ * This file is part of composer/xdebug-handler.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Composer\XdebugHandler;
+
+/**
+ * @author John Stevenson <john-stevenson@blueyonder.co.uk>
+ */
+class XdebugHandler
+{
+    const ENV_ALLOW = 'COMPOSER_ALLOW_XDEBUG';
+    const ENV_ORIGINAL = 'COMPOSER_ORIGINAL_INIS';
+    const ENV_VERSION = 'COMPOSER_XDEBUG_VERSION';
+    const RESTART_ID = 'internal';
+
+    private $loaded;
+    private $envScanDir;
+    private $version;
+    private $tmpIni;
+
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        $this->loaded = extension_loaded('xdebug');
+        $this->envScanDir = getenv('PHP_INI_SCAN_DIR');
+
+        if ($this->loaded) {
+            $ext = new \ReflectionExtension('xdebug');
+            $this->version = strval($ext->getVersion());
+        }
+    }
+
+    /**
+     * Checks if xdebug is loaded and composer needs to be restarted
+     *
+     * If so, then a tmp ini is created with the xdebug ini entry commented out.
+     * If additional inis have been loaded, these are combined into the tmp ini
+     * and PHP_INI_SCAN_DIR is set to an empty value. Current ini locations are
+     * are stored in COMPOSER_ORIGINAL_INIS, for use in the restarted process.
+     *
+     * This behaviour can be disabled by setting the COMPOSER_ALLOW_XDEBUG
+     * environment variable to 1. This variable is used internally so that the
+     * restarted process is created only once and PHP_INI_SCAN_DIR can be
+     * restored to its original value.
+     */
+    public function check()
+    {
+        $args = explode('|', strval(getenv(self::ENV_ALLOW)), 2);
+
+        if ($this->needsRestart($args[0])) {
+            if ($this->prepareRestart()) {
+                $command = $this->getCommand();
+                $this->restart($command);
+            }
+
+            return;
+        }
+
+        // Restore environment variables if we are restarting
+        if (self::RESTART_ID === $args[0]) {
+            putenv(self::ENV_ALLOW);
+
+            if (false !== $this->envScanDir) {
+                // $args[1] contains the original value
+                if (isset($args[1])) {
+                    putenv('PHP_INI_SCAN_DIR='.$args[1]);
+                } else {
+                    putenv('PHP_INI_SCAN_DIR');
+                }
+            }
+
+            // Clear version if the restart failed to disable xdebug
+            if ($this->loaded) {
+                putenv(self::ENV_VERSION);
+            }
+        }
+    }
+
+    /**
+     * Returns an array of php.ini locations with at least one entry
+     *
+     * The equivalent of calling php_ini_loaded_file then php_ini_scanned_files.
+     * The loaded ini location is the first entry and may be empty.
+     *
+     * @return array
+     */
+    public static function getAllIniFiles()
+    {
+        $env = getenv(self::ENV_ORIGINAL);
+
+        if (false !== $env) {
+            return explode(PATH_SEPARATOR, $env);
+        }
+
+        $paths = array(strval(php_ini_loaded_file()));
+
+        if ($scanned = php_ini_scanned_files()) {
+            $paths = array_merge($paths, array_map('trim', explode(',', $scanned)));
+        }
+
+        return $paths;
+    }
+
+    /**
+     * Executes the restarted command then deletes the tmp ini
+     *
+     * @param string $command
+     */
+    protected function restart($command)
+    {
+        passthru($command, $exitCode);
+
+        if (!empty($this->tmpIni)) {
+            @unlink($this->tmpIni);
+        }
+
+        exit($exitCode);
+    }
+
+    /**
+     * Returns true if a restart is needed
+     *
+     * @param string $allow Environment value
+     *
+     * @return bool
+     */
+    private function needsRestart($allow)
+    {
+        if (PHP_SAPI !== 'cli' || !defined('PHP_BINARY')) {
+            return false;
+        }
+
+        return empty($allow) && $this->loaded;
+    }
+
+    /**
+     * Returns true if everything was written for the restart
+     *
+     * If any of the following fails (however unlikely) we must return false to
+     * stop potential recursion:
+     *   - tmp ini file creation
+     *   - environment variable creation
+     *
+     * @return bool
+     */
+    private function prepareRestart()
+    {
+        $this->tmpIni = '';
+        $iniPaths = self::getAllIniFiles();
+        $additional = count($iniPaths) > 1;
+
+        if ($this->writeTmpIni($iniPaths)) {
+            return $this->setEnvironment($additional, $iniPaths);
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns true if the tmp ini file was written
+     *
+     * The filename is passed as the -c option when the process restarts.
+     *
+     * @param array $iniPaths Locations reported by the current process
+     *
+     * @return bool
+     */
+    private function writeTmpIni(array $iniPaths)
+    {
+        if (!$this->tmpIni = tempnam(sys_get_temp_dir(), '')) {
+            return false;
+        }
+
+        // $iniPaths has at least one item and it may be empty
+        if (empty($iniPaths[0])) {
+            array_shift($iniPaths);
+        }
+
+        $content = '';
+        $regex = '/^\s*(zend_extension\s*=.*xdebug.*)$/mi';
+
+        foreach ($iniPaths as $file) {
+            $data = preg_replace($regex, ';$1', file_get_contents($file));
+            $content .= $data.PHP_EOL;
+        }
+
+        $content .= 'allow_url_fopen='.ini_get('allow_url_fopen').PHP_EOL;
+        $content .= 'disable_functions="'.ini_get('disable_functions').'"'.PHP_EOL;
+        $content .= 'memory_limit='.ini_get('memory_limit').PHP_EOL;
+
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            // Work-around for PHP windows bug, see issue #6052
+            $content .= 'opcache.enable_cli=0'.PHP_EOL;
+        }
+
+        return @file_put_contents($this->tmpIni, $content);
+    }
+
+    /**
+     * Returns the restart command line
+     *
+     * @return string
+     */
+    private function getCommand()
+    {
+        $phpArgs = array(PHP_BINARY, '-c', $this->tmpIni);
+        $params = array_merge($phpArgs, $this->getScriptArgs($_SERVER['argv']));
+
+        return implode(' ', array_map(array($this, 'escape'), $params));
+    }
+
+    /**
+     * Returns true if the restart environment variables were set
+     *
+     * @param bool  $additional Whether there were additional inis
+     * @param array $iniPaths Locations reported by the current process
+     *
+     * @return bool
+     */
+    private function setEnvironment($additional, array $iniPaths)
+    {
+        // Set scan dir to an empty value if additional ini files were used
+        if ($additional && !putenv('PHP_INI_SCAN_DIR=')) {
+            return false;
+        }
+
+        // Make original inis available to restarted process
+        if (!putenv(self::ENV_ORIGINAL.'='.implode(PATH_SEPARATOR, $iniPaths))) {
+            return false;
+        }
+
+        // Make xdebug version available to restarted process
+        if (!putenv(self::ENV_VERSION.'='.$this->version)) {
+            return false;
+        }
+
+        // Flag restarted process and save env scan dir state
+        $args = array(self::RESTART_ID);
+
+        if (false !== $this->envScanDir) {
+            // Save current PHP_INI_SCAN_DIR
+            $args[] = $this->envScanDir;
+        }
+
+        return putenv(self::ENV_ALLOW.'='.implode('|', $args));
+    }
+
+    /**
+     * Returns the restart script arguments, adding --ansi if required
+     *
+     * If we are a terminal with color support we must ensure that the --ansi
+     * option is set, because the restarted output is piped.
+     *
+     * @param array $args The argv array
+     *
+     * @return array
+     */
+    private function getScriptArgs(array $args)
+    {
+        if (in_array('--no-ansi', $args) || in_array('--ansi', $args)) {
+            return $args;
+        }
+
+        if ($this->hasColorOutput(STDOUT)) {
+            $offset = count($args) > 1 ? 2 : 1;
+            array_splice($args, $offset, 0, '--ansi');
+        }
+
+        return $args;
+    }
+
+    /**
+     * Escapes a string to be used as a shell argument.
+     *
+     * From https://github.com/johnstevenson/winbox-args
+     * MIT Licensed (c) John Stevenson <john-stevenson@blueyonder.co.uk>
+     *
+     * @param string $arg  The argument to be escaped
+     * @param bool   $meta Additionally escape cmd.exe meta characters
+     *
+     * @return string The escaped argument
+     */
+    private function escape($arg, $meta = true)
+    {
+        if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
+            return escapeshellarg($arg);
+        }
+
+        $quote = strpbrk($arg, " \t") !== false || $arg === '';
+        $arg = preg_replace('/(\\\\*)"/', '$1$1\\"', $arg, -1, $dquotes);
+
+        if ($meta) {
+            $meta = $dquotes || preg_match('/%[^%]+%/', $arg);
+
+            if (!$meta && !$quote) {
+                $quote = strpbrk($arg, '^&|<>()') !== false;
+            }
+        }
+
+        if ($quote) {
+            $arg = preg_replace('/(\\\\*)$/', '$1$1', $arg);
+            $arg = '"'.$arg.'"';
+        }
+
+        if ($meta) {
+            $arg = preg_replace('/(["^&|<>()%])/', '^$1', $arg);
+        }
+
+        return $arg;
+    }
+
+    /**
+     * Returns true if the output stream supports colors
+     *
+     * @param mixed $output A valid output stream
+     *
+     * @return bool
+     */
+    private function hasColorOutput($output)
+    {
+        if (defined(PHP_WINDOWS_VERSION_MAJOR)) {
+            // Switch on vt100 support if we can
+            if (function_exists('sapi_windows_vt100_output')) {
+                return sapi_windows_vt100_support($output, true);
+            }
+
+            $stat = fstat($output);
+            // Check if formatted mode is S_IFCHR
+            $isatty = $stat ? 0020000 === ($stat['mode'] & 0170000) : false;
+
+            return $isatty
+                && (false !== getenv('ANSICON')
+                || 'ON' === getenv('ConEmuANSI')
+                || 'xterm' === getenv('TERM')
+                || 'cygwin' === getenv('TERM'));
+        }
+
+        return function_exists('posix_isatty') && posix_isatty($output);
+    }
+}

--- a/tests/XdebugHandlerMock.php
+++ b/tests/XdebugHandlerMock.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of composer/xdebug-handler.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Composer\XdebugHandler;
+
+class XdebugHandlerMock extends XdebugHandler
+{
+    public $restarted;
+    public $testVersion = '2.5.0';
+
+    public function __construct($loaded = null)
+    {
+        parent::__construct();
+
+        $loaded = null === $loaded ? true : $loaded;
+        $class = new \ReflectionClass(get_parent_class($this));
+
+        $prop = $class->getProperty('loaded');
+        $prop->setAccessible(true);
+        $prop->setValue($this, $loaded);
+
+        $prop = $class->getProperty('version');
+        $prop->setAccessible(true);
+        $version = $loaded ? $this->testVersion : '';
+        $prop->setValue($this, $version);
+
+        $this->restarted = false;
+    }
+
+    protected function restart($command)
+    {
+        $this->restarted = true;
+    }
+}

--- a/tests/XdebugHandlerTest.php
+++ b/tests/XdebugHandlerTest.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * This file is part of composer/xdebug-handler.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Composer\XdebugHandler;
+
+use Composer\XdebugHandler\XdebugHandlerMock;
+
+/**
+ * We use PHP_BINARY which only became available in PHP 5.4
+ *
+ * @requires PHP 5.4
+ */
+class XdebugHandlerTest extends \PHPUnit\Framework\TestCase
+{
+    public static $env = array();
+
+    public function testRestartWhenLoaded()
+    {
+        $loaded = true;
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertTrue($xdebug->restarted);
+        $this->assertInternalType('string', getenv(XdebugHandlerMock::ENV_ORIGINAL));
+    }
+
+    public function testNoRestartWhenNotLoaded()
+    {
+        $loaded = false;
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertFalse($xdebug->restarted);
+        $this->assertFalse(getenv(XdebugHandlerMock::ENV_ORIGINAL));
+    }
+
+    public function testNoRestartWhenLoadedAndAllowed()
+    {
+        $loaded = true;
+        putenv(XdebugHandlerMock::ENV_ALLOW.'=1');
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertFalse($xdebug->restarted);
+    }
+
+    public function testEnvAllow()
+    {
+        $loaded = true;
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $expected = XdebugHandlerMock::RESTART_ID;
+        $this->assertEquals($expected, getenv(XdebugHandlerMock::ENV_ALLOW));
+
+        // Mimic restart
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertFalse($xdebug->restarted);
+        $this->assertFalse(getenv(XdebugHandlerMock::ENV_ALLOW));
+    }
+
+    public function testEnvAllowWithScanDir()
+    {
+        $loaded = true;
+        $dir = '/some/where';
+        putenv('PHP_INI_SCAN_DIR='.$dir);
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $expected = XdebugHandlerMock::RESTART_ID.'|'.$dir;
+        $this->assertEquals($expected, getenv(XdebugHandlerMock::ENV_ALLOW));
+
+        // Mimic setting scan dir and restart
+        putenv('PHP_INI_SCAN_DIR=');
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertEquals($dir, getenv('PHP_INI_SCAN_DIR'));
+    }
+
+    public function testEnvAllowWithEmptyScanDir()
+    {
+        $loaded = true;
+        putenv('PHP_INI_SCAN_DIR=');
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $expected = XdebugHandlerMock::RESTART_ID.'|';
+        $this->assertEquals($expected, getenv(XdebugHandlerMock::ENV_ALLOW));
+
+        // Unset scan dir and mimic restart
+        putenv('PHP_INI_SCAN_DIR');
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertEquals('', getenv('PHP_INI_SCAN_DIR'));
+    }
+
+    public function testEnvVersionWhenLoaded()
+    {
+        $loaded = true;
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertEquals($xdebug->testVersion, getenv(XdebugHandlerMock::ENV_VERSION));
+
+        // Mimic successful restart
+        $loaded = false;
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertEquals($xdebug->testVersion, getenv(XdebugHandlerMock::ENV_VERSION));
+    }
+
+    public function testEnvVersionWhenNotLoaded()
+    {
+        $loaded = false;
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertEquals(false, getenv(XdebugHandlerMock::ENV_VERSION));
+    }
+
+    public function testEnvVersionWhenRestartFails()
+    {
+        $loaded = true;
+
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+
+        // Mimic failed restart
+        $xdebug = new XdebugHandlerMock($loaded);
+        $xdebug->check();
+        $this->assertEquals(false, getenv(XdebugHandlerMock::ENV_VERSION));
+    }
+
+    public static function setUpBeforeClass()
+    {
+        // Save current state
+        $names = array(
+            XdebugHandlerMock::ENV_ALLOW,
+            XdebugHandlerMock::ENV_VERSION,
+            'PHP_INI_SCAN_DIR',
+            XdebugHandlerMock::ENV_ORIGINAL,
+        );
+
+        foreach ($names as $name) {
+            self::$env[$name] = getenv($name);
+        }
+    }
+
+    public static function tearDownAfterClass()
+    {
+        // Restore original state
+        foreach (self::$env as $name => $value) {
+            if (false !== $value) {
+                putenv($name.'='.$value);
+            } else {
+                putenv($name);
+            }
+        }
+    }
+
+    protected function setUp()
+    {
+        // Ensure env is unset
+        putenv(XdebugHandlerMock::ENV_ALLOW);
+        putenv(XdebugHandlerMock::ENV_VERSION);
+        putenv('PHP_INI_SCAN_DIR');
+        putenv(XdebugHandlerMock::ENV_ORIGINAL);
+    }
+}

--- a/tests/XdebugIniTest.php
+++ b/tests/XdebugIniTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of composer/xdebug-handler.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Composer\XdebugHandler;
+
+use Composer\XdebugHandler\XdebugHandler;
+
+class IniHelperTest extends \PHPUnit\Framework\TestCase
+{
+    public static $envOriginal;
+
+    public function testWithNoIni()
+    {
+        $paths = array(
+            '',
+        );
+
+        $this->setEnv($paths);
+        $this->assertEquals($paths, XdebugHandler::getAllIniFiles());
+    }
+
+    public function testWithLoadedIniOnly()
+    {
+        $paths = array(
+            'loaded.ini',
+        );
+
+        $this->setEnv($paths);
+        $this->assertEquals($paths, XdebugHandler::getAllIniFiles());
+    }
+
+    public function testWithLoadedIniAndAdditional()
+    {
+        $paths = array(
+            'loaded.ini',
+            'one.ini',
+            'two.ini',
+        );
+
+        $this->setEnv($paths);
+        $this->assertEquals($paths, XdebugHandler::getAllIniFiles());
+    }
+
+    public function testWithoutLoadedIniAndAdditional()
+    {
+        $paths = array(
+            '',
+            'one.ini',
+            'two.ini',
+        );
+
+        $this->setEnv($paths);
+        $this->assertEquals($paths, XdebugHandler::getAllIniFiles());
+    }
+
+    public static function setUpBeforeClass()
+    {
+        // Save current state
+        self::$envOriginal = getenv(XdebugHandler::ENV_ORIGINAL);
+    }
+
+    public static function tearDownAfterClass()
+    {
+        // Restore original state
+        if (false !== self::$envOriginal) {
+            putenv(XdebugHandler::ENV_ORIGINAL.'='.self::$envOriginal);
+        } else {
+            putenv(XdebugHandler::ENV_ORIGINAL);
+        }
+    }
+
+    protected function setEnv(array $paths)
+    {
+        putenv(XdebugHandler::ENV_ORIGINAL.'='.implode(PATH_SEPARATOR, $paths));
+    }
+}


### PR DESCRIPTION
The main items that needed to be changed were the dependencies on `Symfony\Component\Console\Output` and `Composer\Utils\IniHelper`.

The former has been replaced by `hasColorOutput()` (which was actually in the early XdebugHandler versions) and the latter with a new static function `getAllIniFiles()`.