### PR TITLE
Fix flaws in detecting color support

### DIFF
--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -346,7 +346,7 @@ class XdebugHandler
     /**
      * Returns true if the output stream supports colors
      *
-     * This is tricky on Windows, because Cgywin, Msys2 etc emulate pseudo
+     * This is tricky on Windows, because Cygwin, Msys2 etc emulate pseudo
      * terminals via named pipes, so we can only check the environment.
      *
      * @param mixed $output A valid output stream


### PR DESCRIPTION
Consistently using the correct new function name would have been a good
start, but in addition the logic was flawed for Windows.

Cygwin and Msys (and therefore Git Bash), emulate pseudo terminals by
using named pipes, so `sapi_windows_vt100_support` and any test for a
tty will fail. However, this is not the case when Git Bash is given the
name of a program to run that requires a PATH lookup, rather than being
given the full filename.

As such, we should only rely on the specific environment variables.