### PR TITLE
Allow output to be logged or disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,20 @@ $version = XdebugHandler::getSkippedVersion();
 ```
 
 ### Output
-The library is silent unless the `-vvv` command-line option is present, which results in the output of simple status messages.
+The library is silent unless the `-vvv` command-line option is present, which results in the output of status messages on stdout.
+
+Output can also be activated using the `setLogger` method, which will redirect messages to the logger with either `INFO` or `ERROR` log levels. Passing null to this method will disable output completely.
+
+```php
+use Composer\XdebugHandler\XdebugHandler;
+
+$xdebug = new XdebugHandler('myapp');
+// Provide a PSR3 logger
+$xdebug->setLogger($myLogger);
+
+// or disable -vvv activated output
+$xdebug->setLogger(null);
+```
 
 ## License
 composer/xdebug-handler is licensed under the MIT License, see the LICENSE file for details.

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "issues": "https://github.com/composer/xdebug-handler/issues"
     },
     "require": {
-        "php": "^5.3.2 || ^7.0"
+        "php": "^5.3.2 || ^7.0",
+        "psr/log": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"

--- a/src/Process.php
+++ b/src/Process.php
@@ -18,8 +18,6 @@ namespace Composer\XdebugHandler;
  */
 class Process
 {
-    private static $colorSupport;
-
     /**
      * Returns the process arguments, appending a color option if required
      *

--- a/tests/Helpers/Logger.php
+++ b/tests/Helpers/Logger.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of composer/xdebug-handler.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Composer\XdebugHandler\Helpers;
+
+use Psr\Log\AbstractLogger;
+
+class Logger extends AbstractLogger
+{
+    protected $output = array();
+
+    public function log($level, $message, array $context = array())
+    {
+        $this->output[] = array($level, $message);
+    }
+
+    public function getOutput()
+    {
+        return $this->output;
+    }
+}

--- a/tests/Mocks/CoreMock.php
+++ b/tests/Mocks/CoreMock.php
@@ -35,8 +35,9 @@ class CoreMock extends XdebugHandler
 
     protected $childProcess;
     protected $refClass;
+    protected static $settings;
 
-    public static function createAndCheck($loaded, $parentProcess = null)
+    public static function createAndCheck($loaded, $parentProcess = null, $settings = array())
     {
         $xdebug = new static($loaded);
 
@@ -45,6 +46,12 @@ class CoreMock extends XdebugHandler
             $xdebug->restarted = true;
             $parentProcess->childProcess = $xdebug;
         }
+
+        foreach ($settings as $method => $args) {
+            call_user_func_array(array($xdebug, $method), $args);
+        }
+
+        static::$settings = $settings;
 
         $xdebug->check();
         return $xdebug->childProcess ?: $xdebug;
@@ -91,6 +98,6 @@ class CoreMock extends XdebugHandler
 
     protected function restart($command)
     {
-        static::createAndCheck(false, $this);
+        static::createAndCheck(false, $this, static::$settings);
     }
 }

--- a/tests/Mocks/FailMock.php
+++ b/tests/Mocks/FailMock.php
@@ -19,6 +19,6 @@ class FailMock extends CoreMock
 {
     protected function restart($command)
     {
-        static::createAndCheck(true, $this);
+        static::createAndCheck(true, $this, static::$settings);
     }
 }

--- a/tests/StatusTest.php
+++ b/tests/StatusTest.php
@@ -12,6 +12,7 @@
 namespace Composer\XdebugHandler;
 
 use Composer\XdebugHandler\Helpers\BaseTestCase;
+use Composer\XdebugHandler\Helpers\Logger;
 use Composer\XdebugHandler\Mocks\CoreMock;
 
 /**
@@ -21,7 +22,18 @@ use Composer\XdebugHandler\Mocks\CoreMock;
  */
 class StatusTest extends BaseTestCase
 {
-    public function testVerboseOptionLoaded()
+    public function testNoDefaultOutput()
+    {
+        $loaded = true;
+
+        $xdebug = CoreMock::createAndCheck($loaded);
+        $this->checkRestart($xdebug);
+
+        $output = $this->getActualOutput();
+        $this->assertEmpty($output);
+    }
+
+    public function testVerboseOptionShowsOutput()
     {
         $loaded = true;
         $_SERVER['argv'][] = '-vvv';
@@ -33,16 +45,33 @@ class StatusTest extends BaseTestCase
         $this->assertNotEmpty($output);
     }
 
-    public function testVerboseOptionNotLoaded()
+    public function testSetLoggerOverridesOutput()
     {
-        $loaded = false;
+        $loaded = true;
         $_SERVER['argv'][] = '-vvv';
 
-        $xdebug = CoreMock::createAndCheck($loaded);
-        $this->checkNoRestart($xdebug);
+        $logger = new Logger();
+        $settings = array('setLogger' => array($logger));
+
+        $xdebug = CoreMock::createAndCheck($loaded, null, $settings);
+        $this->checkRestart($xdebug);
+
+        $this->assertNotEmpty($logger->getOutput());
+        $output = $this->getActualOutput();
+        $this->assertEmpty($output);
+    }
+
+    public function testSetLoggerNullDisablesOutput()
+    {
+        $loaded = true;
+        $_SERVER['argv'][] = '-vvv';
+
+        $settings = array('setLogger' => array(null));
+        $xdebug = CoreMock::createAndCheck($loaded, null, $settings);
+        $this->checkRestart($xdebug);
 
         $output = $this->getActualOutput();
-        $this->assertNotEmpty($output);
+        $this->assertEmpty($output);
     }
 
     protected function setUp()


### PR DESCRIPTION
Submitted as the result of discussions after the original [PR to add status output](https://github.com/composer/xdebug-handler/pull/28) 

```
// send INFO and ERROR messages to a PSR3 Logger
$xdebug->setLogger($myLogger);

// disable output (overrides -vvv option)
$xdebug->setLogger(null);
```