### PR TITLE
Fixed failures when PHP code is supplied on stdin

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,6 +13,12 @@
     <testsuites>
         <testsuite name="XdebugHandler Test Suite">
             <directory>tests</directory>
+            <exclude>tests/StdinName72Test.php</exclude>
+            <exclude>tests/StdinNameLegacyTest.php</exclude>
+        </testsuite>
+        <testsuite name="XDebugHandler version-dependent test suite">
+            <file phpVersion="7.2.0">tests/StdinName72Test.php</file>
+            <file phpVersion="7.2.0" phpVersionOperator="&lt;">tests/StdinNameLegacyTest.php</file>
         </testsuite>
     </testsuites>
 

--- a/src/Process.php
+++ b/src/Process.php
@@ -126,4 +126,29 @@ class Process
         // Check if formatted mode is S_IFCHR
         return $stat ? 0020000 === ($stat['mode'] & 0170000) : false;
     }
+
+    /**
+     * Fixes stdin filename when php is interpreting code on stdin
+     *
+     * Replaces stdin "filename" (which depends on PHP version ) with '--'
+     * to prevent interpreting it and subsequent arguments as script file name.
+     *
+     * @param array $args The argv array
+     * @return array
+     */
+    public static function fixStdinName(array $args)
+    {
+        // before 7.2 stdin input file was named php://stdin
+        // it's named 'Standard input code' since 7.2
+        // see github.com/php/php-src/commit/3ed8b7a87b5383f9ba99a0bbcea6e9fe7a070946
+        $stdinName = PHP_VERSION_ID < 70200
+            ? 'php://stdin'
+            : 'Standard input code';
+
+        if ($args[0] === $stdinName) {
+            $args[0] = '--';
+        }
+
+        return $args;
+    }
 }

--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -269,6 +269,8 @@ class XdebugHandler
             $args = Process::addColorOption($args, $this->colorOption);
         }
 
+        $args = Process::fixStdinName($args);
+
         $args = array_merge(array(PHP_BINARY, '-c', $this->tmpIni), $args);
 
         $cmd = Process::escape(array_shift($args), true, true);

--- a/tests/StdinName72Test.php
+++ b/tests/StdinName72Test.php
@@ -1,0 +1,26 @@
+<?php
+namespace Composer\XDebugHandler;
+
+use PHPUnit\Framework\TestCase;
+use Composer\XdebugHandler\Process;
+
+/**
+ * This class does not need to extend Helpers\BaseTestCase
+ */
+class StdinName72Test extends TestCase
+{
+    public function testReplacesStandardInputCode()
+    {
+        $args = ['Standard input code', 'asd'];
+        $this->assertEquals(
+            ['--', 'asd'],
+            Process::fixStdinName($args)
+        );
+    }
+
+    public function testScriptFilenameIsLeftIntact()
+    {
+        $args = ['script.php', 'asd'];
+        $this->assertEquals($args, Process::fixStdinName($args));
+    }
+}

--- a/tests/StdinNameLegacyTest.php
+++ b/tests/StdinNameLegacyTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace Composer\XDebugHandler;
+
+use PHPUnit\Framework\TestCase;
+use Composer\XdebugHandler\Process;
+
+/**
+ * This class does not need to extend Helpers\BaseTestCase
+ */
+class StdinNameLegacyTest extends TestCase
+{
+    public function testReplacesStdin()
+    {
+        $args = ['php://stdin', 'asd'];
+        $this->assertEquals(
+            ['--', 'asd'],
+            Process::fixStdinName($args)
+        );
+    }
+
+    public function testScriptFilenameIsLeftIntact()
+    {
+        $args = ['script.php', 'asd'];
+        $this->assertEquals($args, Process::fixStdinName($args));
+    }
+}


### PR DESCRIPTION
When PHP is interpreting the code from STDIN (as opposed to executing a script file) it sets $argv[0] to a hardcoded string (specific string depends on PHP version). XDebugHandler was supplying this string to the
restarted subprocess, which subsequently failed with 'Could not open input file: ...'.

Now these strings are replaced with '--' and the subprocess does not fail.