### PR TITLE
Prevent restart with directly executed code

### DIFF
--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -205,6 +205,8 @@ class XdebugHandler
             $error = 'Unsupported SAPI: '.PHP_SAPI;
         } elseif (!defined('PHP_BINARY')) {
             $error = 'PHP version is too old: '.PHP_VERSION;
+        } elseif (!file_exists($_SERVER['argv'][0])) {
+            $error = 'Directly executed code is not supported';
         } elseif (!$this->writeTmpIni($iniFiles)) {
             $error = 'Unable to create temporary ini file';
         } elseif (!$this->setEnvironment($scannedInis, $scanDir, $iniFiles)) {

--- a/tests/RestartTest.php
+++ b/tests/RestartTest.php
@@ -54,4 +54,13 @@ class RestartTest extends BaseTestCase
         $xdebug = FailMock::createAndCheck($loaded);
         $this->checkRestart($xdebug);
     }
+
+    public function testNoRestartWhenLoadedAndNoScript()
+    {
+        $loaded = true;
+        $_SERVER['argv'][0] = '-';
+
+        $xdebug = CoreMock::createAndCheck($loaded);
+        $this->checkNoRestart($xdebug);
+    }
 }


### PR DESCRIPTION
Code that is executed directly (from stdin, --run or interactively)
cannot be used in a restarted process.

Thanks to Bruce Weirdan https://github.com/weirdan