### PR TITLE
Now allow a restart with all directly executed code

### DIFF
--- a/src/Status.php
+++ b/src/Status.php
@@ -22,6 +22,7 @@ class Status
     const ENV_RESTART = 'XDEBUG_HANDLER_RESTART';
     const CHECK = 'Check';
     const ERROR = 'Error';
+    const INFO = 'Info';
     const NORESTART = 'NoRestart';
     const RESTART = 'Restart';
     const RESTARTING = 'Restarting';
@@ -81,6 +82,11 @@ class Status
     private function reportError($error)
     {
         $this->output(sprintf("No restart (%s)", $error), LogLevel::WARNING);
+    }
+
+    private function reportInfo($info)
+    {
+        $this->output($info);
     }
 
     private function reportNoRestart()

--- a/tests/RestartTest.php
+++ b/tests/RestartTest.php
@@ -55,12 +55,12 @@ class RestartTest extends BaseTestCase
         $this->checkRestart($xdebug);
     }
 
-    public function testNoRestartWhenLoadedAndNoScript()
+    public function testRestartWhenLoadedAndNoScript()
     {
         $loaded = true;
         $_SERVER['argv'][0] = '-';
 
         $xdebug = CoreMock::createAndCheck($loaded);
-        $this->checkNoRestart($xdebug);
+        $this->checkRestart($xdebug);
     }
 }


### PR DESCRIPTION
If XdebugHandler is auto-prepended, stdin can be read by the restarted
process. If this is not the case, then the restarted process will have
nothing to execute and will exit immediately if it is not interactive.

Status messages have been added to show if directly executed code is
being used and to report when the restarted process exits. Additionally
the constant STDOUT is checked before use, as it is not defined when
code is provided via stdin.

Thanks again to Bruce Weirdan https://github.com/weirdan