### PR TITLE
Various tweaks

### DIFF
--- a/src/Process.php
+++ b/src/Process.php
@@ -23,8 +23,8 @@ class Process
      *
      * A color option is needed because child process output is piped.
      *
-     * @param array $args The argv array
-     * @param $colorOption The long option to force color output
+     * @param array  $args        The argv array
+     * @param string $colorOption The long option to force color output
      *
      * @return array
      */
@@ -118,7 +118,8 @@ class Process
 
         if (function_exists('stream_isatty')) {
             return stream_isatty($output);
-        } elseif (function_exists('posix_isatty')) {
+        }
+        if (function_exists('posix_isatty')) {
             return posix_isatty($output);
         }
 

--- a/src/Status.php
+++ b/src/Status.php
@@ -99,7 +99,7 @@ class Status
         }
     }
 
-    private function reportRestart()
+    private function reportRestart($info)
     {
         $this->output($this->getLoadedMessage());
         putenv(self::ENV_RESTART.'='.strval(microtime(true)));
@@ -113,9 +113,9 @@ class Status
         $this->output($text, $level);
     }
 
-    private function reportRestarting()
+    private function reportRestarting($info)
     {
-        $text = sprintf("Process restarting (%s)", $this->getEnvAllow());
+        $text = sprintf("Process restarting (%s): %s", $this->getEnvAllow(), $info);
         $this->output($text);
     }
 

--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -30,6 +30,7 @@ class XdebugHandler
     private $envAllowXdebug;
     private $envOriginalInis;
     private $loaded;
+    /** @var Status|null */
     private $statusWriter;
     private $tmpIni;
 
@@ -42,7 +43,7 @@ class XdebugHandler
      *
      * @param string $envPrefix Value used in environment variables
      * @param string $colorOption Command-line long option to force color output
-     * @throws RuntimeException If a parameter is invalid
+     * @throws \RuntimeException If a parameter is invalid
      */
     public function __construct($envPrefix, $colorOption = '')
     {
@@ -98,7 +99,7 @@ class XdebugHandler
 
             if ($this->prepareRestart()) {
                 $command = $this->getCommand($_SERVER['argv']);
-                $this->notify(Status::RESTARTING);
+                $this->notify(Status::RESTARTING, $command);
                 $this->restart($command);
             }
             return;
@@ -165,7 +166,7 @@ class XdebugHandler
      */
     public static function getSkippedVersion()
     {
-        return strval(self::$skipped);
+        return (string) self::$skipped;
     }
 
     /**

--- a/tests/ConstructorTest.php
+++ b/tests/ConstructorTest.php
@@ -19,29 +19,29 @@ use PHPUnit\Framework\TestCase;
 class ConstructorTest extends TestCase
 {
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      *
      */
     public function testThrowsOnEmptyEnvPrefix()
     {
-        $xdebug = new XdebugHandler('');
+        new XdebugHandler('');
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      *
      */
     public function testThrowsOnInvalidEnvPrefix()
     {
-        $xdebug = new XdebugHandler(array('name'));
+        new XdebugHandler(array('name'));
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      *
      */
     public function testThrowsOnInvalidColorOption()
     {
-        $xdebug = new XdebugHandler('test', false);
+        new XdebugHandler('test', false);
     }
 }

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -45,7 +45,7 @@ class EnvironmentTest extends BaseTestCase
         }
 
         $loaded = true;
-        $xdebug = PartialMock::createAndCheck($loaded);
+        PartialMock::createAndCheck($loaded);
         $this->assertSame($expected, getenv(CoreMock::ALLOW_XDEBUG));
     }
 
@@ -84,7 +84,7 @@ class EnvironmentTest extends BaseTestCase
         }
 
         $loaded = true;
-        $xdebug = PartialMock::createAndCheck($loaded);
+        PartialMock::createAndCheck($loaded);
         $this->assertSame($expected, getenv('PHP_INI_SCAN_DIR'));
     }
 

--- a/tests/IniFilesTest.php
+++ b/tests/IniFilesTest.php
@@ -121,7 +121,7 @@ class IniFilesTest extends BaseTestCase
     {
         $tmpIni = $xdebug->getProperty('tmpIni');
 
-        if (!$tmpIni = $xdebug->getProperty('tmpIni')) {
+        if (!$tmpIni) {
             $this->fail('The tmpIni file was not created');
         }
 


### PR DESCRIPTION
- Remove unused variable assignments
- Fix the exception class used (either need a use statement or it should be the FQCN)
- Fix `Process::addColorOption()` phpdoc
- Use cast syntax rather than `strval()` as this is faster
- Add missing phpdoc for the lazily assigned `XdebugHandler#statusWriter` to enable auto-completion
- Log the command use to restart the process