### PR TITLE
Allow XdebugHandler to tweak PHP ini settings

### DIFF
--- a/tests/Mocks/CoreMock.php
+++ b/tests/Mocks/CoreMock.php
@@ -68,6 +68,11 @@ class CoreMock extends XdebugHandler
         $prop->setAccessible(true);
         $prop->setValue($this, $loaded ? static::TEST_VERSION : null);
 
+        // Set private restart
+        $prop = $this->refClass->getProperty('restart');
+        $prop->setAccessible(true);
+        $prop->setValue($this, $loaded ? true : false);
+
         // Ensure static private skipped is unset
         $prop = $this->refClass->getProperty('skipped');
         $prop->setAccessible(true);


### PR DESCRIPTION
The goal of this PR is to provide enough extension point to tweak other PHP ini settings liked required in Box cf. https://github.com/humbug/box/pull/91.

This PR provides two entry points:

- One is to calculate whether or not if a restart is needed. Prior to this PR checking if `$this->loaded` was not `null` was enough. However now this might be determined by other things (e.g. the value of a an ini setting).
- Another is to provide the list of ini settings to use: one can now extend it and change the settings as he/she see fit