### PR TITLE
Update $_SERVER environment in restarted process

### DIFF
--- a/src/Process.php
+++ b/src/Process.php
@@ -12,7 +12,8 @@
 namespace Composer\XdebugHandler;
 
 /**
- * Provides utility functions to prepare a child process command-line.
+ * Provides utility functions to prepare a child process command-line and set
+ * environment variables in that process.
  *
  * @author John Stevenson <john-stevenson@blueyonder.co.uk>
  */
@@ -125,5 +126,29 @@ class Process
         $stat = fstat($output);
         // Check if formatted mode is S_IFCHR
         return $stat ? 0020000 === ($stat['mode'] & 0170000) : false;
+    }
+
+    /**
+     * Makes putenv environment changes available in $_SERVER
+     *
+     * @param string $name
+     * @param string|false $value A false value unsets the variable
+     *
+     * @return bool Whether the environment variable was set
+     */
+    public static function setEnv($name, $value = false)
+    {
+        $unset = false === $value;
+
+        if (!putenv($unset ? $name : $name.'='.$value)) {
+            return false;
+        }
+
+        if ($unset) {
+            unset($_SERVER[$name]);
+        } else {
+            $_SERVER[$name] = $value;
+        }
+        return true;
     }
 }

--- a/src/Status.php
+++ b/src/Status.php
@@ -11,6 +11,7 @@
 
 namespace Composer\XdebugHandler;
 
+use Composer\XdebugHandler\Process;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
@@ -43,7 +44,7 @@ class Status
     public function __construct(LoggerInterface $logger, $loaded, $envAllowXdebug)
     {
         $start = getenv(self::ENV_RESTART);
-        putenv(self::ENV_RESTART);
+        Process::setEnv(self::ENV_RESTART);
         $this->time = $start ? round((microtime(true) - $start) * 1000) : 0;
 
         $this->logger = $logger;
@@ -102,7 +103,7 @@ class Status
     private function reportRestart()
     {
         $this->output($this->getLoadedMessage());
-        putenv(self::ENV_RESTART.'='.strval(microtime(true)));
+        Process::setEnv(self::ENV_RESTART, strval(microtime(true)));
     }
 
     private function reportRestarted()

--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -120,7 +120,7 @@ class XdebugHandler
             // Restarting, so unset environment variable and extract saved values
             $this->notify(Status::RESTARTED);
 
-            putenv($this->envAllowXdebug);
+            Process::setEnv($this->envAllowXdebug);
             $version = $envArgs[1];
             $scannedInis = $envArgs[2];
 
@@ -132,9 +132,9 @@ class XdebugHandler
             if ($scannedInis) {
                 // Scan dir will have been changed, so restore it
                 if (isset($envArgs[3])) {
-                    putenv('PHP_INI_SCAN_DIR='.$envArgs[3]);
+                    Process::setEnv('PHP_INI_SCAN_DIR', $envArgs[3]);
                 } else {
-                    putenv('PHP_INI_SCAN_DIR');
+                    Process::setEnv('PHP_INI_SCAN_DIR');
                 }
             }
             return;
@@ -297,6 +297,8 @@ class XdebugHandler
 
     /**
      * Returns true if the restart environment variables were set
+     *
+     * No need to update $_SERVER since this is set in the restarted process.
      *
      * @param bool $scannedInis Whether there were scanned ini files
      * @param false|string $scanDir PHP_INI_SCAN_DIR environment variable

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -37,12 +37,7 @@ class EnvironmentTest extends BaseTestCase
     {
         $ini = new IniHelper();
         call_user_func(array($ini, $iniFunc));
-
-        if (false !== $scandir) {
-            putenv('PHP_INI_SCAN_DIR='.$scandir);
-        } else {
-            putenv('PHP_INI_SCAN_DIR');
-        }
+        $this->setScanDir($scandir);
 
         $loaded = true;
         PartialMock::createAndCheck($loaded);
@@ -76,12 +71,7 @@ class EnvironmentTest extends BaseTestCase
     {
         $ini = new IniHelper();
         call_user_func(array($ini, $iniFunc));
-
-        if (false !== $scandir) {
-            putenv('PHP_INI_SCAN_DIR='.$scandir);
-        } else {
-            putenv('PHP_INI_SCAN_DIR');
-        }
+        $this->setScanDir($scandir);
 
         $loaded = true;
         PartialMock::createAndCheck($loaded);
@@ -90,7 +80,7 @@ class EnvironmentTest extends BaseTestCase
 
     public function scanDirProvider()
     {
-        // $iniFunc, $scandir, $expected (PHP_INI_SCAN_DIR value for reatart)
+        // $iniFunc, $scandir, $expected (PHP_INI_SCAN_DIR value for restart)
         return array(
             'loaded-ini false' => array('setLoadedIni', false, false),
             'loaded-ini empty' => array('setLoadedIni', '', ''),
@@ -112,17 +102,29 @@ class EnvironmentTest extends BaseTestCase
     {
         $ini = new IniHelper();
         call_user_func(array($ini, $iniFunc));
-
-        if (false !== $scandir) {
-            putenv('PHP_INI_SCAN_DIR='.$scandir);
-        } else {
-            putenv('PHP_INI_SCAN_DIR');
-        }
+        $this->setScanDir($scandir);
 
         $loaded = true;
         $xdebug = CoreMock::createAndCheck($loaded);
 
         $this->checkRestart($xdebug);
         $this->assertSame($scandir, getenv('PHP_INI_SCAN_DIR'));
+
+        if (false !== $scandir) {
+            $this->assertSame($scandir, $_SERVER['PHP_INI_SCAN_DIR']);
+        } else {
+            $this->assertSame(false, isset($_SERVER['PHP_INI_SCAN_DIR']));
+        }
+    }
+
+    private function setScanDir($value)
+    {
+        if (false !== $value) {
+            putenv('PHP_INI_SCAN_DIR='.$value);
+            $_SERVER['PHP_INI_SCAN_DIR'] = $value;
+        } else {
+            putenv('PHP_INI_SCAN_DIR');
+            unset($_SERVER['PHP_INI_SCAN_DIR']);
+        }
     }
 }

--- a/tests/Helpers/BaseTestCase.php
+++ b/tests/Helpers/BaseTestCase.php
@@ -37,6 +37,7 @@ abstract class BaseTestCase extends TestCase
     {
         foreach (self::$names as $name) {
             self::$env[$name] = getenv($name);
+            // Note $_SERVER will already match
         }
 
         self::$argv = $_SERVER['argv'];
@@ -50,8 +51,10 @@ abstract class BaseTestCase extends TestCase
         foreach (self::$env as $name => $value) {
             if (false !== $value) {
                 putenv($name.'='.$value);
+                $_SERVER[$name] = $value;
             } else {
                 putenv($name);
+                unset($_SERVER[$name]);
             }
         }
 
@@ -66,6 +69,7 @@ abstract class BaseTestCase extends TestCase
     {
         foreach (self::$names as $name) {
             putenv($name);
+            unset($_SERVER[$name]);
         }
 
         $_SERVER['argv'] = self::$argv;
@@ -83,9 +87,11 @@ abstract class BaseTestCase extends TestCase
 
         // Env ALLOW_XDEBUG must be unset
         $this->assertSame(false, getenv(CoreMock::ALLOW_XDEBUG));
+        $this->assertSame(false, isset($_SERVER[CoreMock::ALLOW_XDEBUG]));
 
         // Env ORIGINAL_INIS must be set and be a string
         $this->assertInternalType('string', getenv(CoreMock::ORIGINAL_INIS));
+        $this->assertSame(true, isset($_SERVER[CoreMock::ORIGINAL_INIS]));
 
         // Skipped version must match xdebug version, or '' if restart fails
         $class = get_class($xdebug);

--- a/tests/Mocks/CoreMock.php
+++ b/tests/Mocks/CoreMock.php
@@ -45,6 +45,8 @@ class CoreMock extends XdebugHandler
             // This is a restart, so set restarted on this instance
             $xdebug->restarted = true;
             $parentProcess->childProcess = $xdebug;
+            // Ensure $_SERVER has our environment changes
+            static::updateServerEnvironment();
         }
 
         foreach ($settings as $method => $args) {
@@ -94,5 +96,23 @@ class CoreMock extends XdebugHandler
     protected function restart($command)
     {
         static::createAndCheck(false, $this, static::$settings);
+    }
+
+    private static function updateServerEnvironment()
+    {
+        $names = array(
+            CoreMock::ALLOW_XDEBUG,
+            CoreMock::ORIGINAL_INIS,
+            'PHP_INI_SCAN_DIR',
+        );
+
+        foreach ($names as $name) {
+            $value = getenv($name);
+            if (false === $value) {
+                unset($_SERVER[$name]);
+            } else {
+                $_SERVER[$name] = $value;
+            }
+        }
     }
 }


### PR DESCRIPTION
It is important that the $_SERVER environment reflects the changes made
when restoring the restart variables. Otherwise a subprocess created
with $_SERVER as its environment will receive restart specific values.
This will break configuration if scanned inis are being used.