### PR TITLE
Make the notify function accessible

### DIFF
--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -375,7 +375,7 @@ class XdebugHandler
      * @param string $op Status handler constant
      * @param null|string $data Optional data
      */
-    private function notify($op, $data = null)
+    final protected function notify($op, $data = null)
     {
         if ($this->statusWriter) {
             $this->statusWriter->report($op, $data);


### PR DESCRIPTION
In the case of Box (again, sorry), I would like to log the fact that I'm appending the `phar.readonly`. For that I would require access to the logger unless I would roll with my own logging (which I easily can do as well). But I think being able to use the existing one would be nicer. That said it does not need to be extendable/configurable so while we change the `notify()` property visibility from `private` to `protected`, I don't think we should allow it to be overridable so I'm proposing to add `final` to it.