### PR TITLE
Store restart settings for use in sub-processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+  * Added: static `getRestartSettings` method for calling PHP processes.
   * Added: API definition and @internal class annotations.
   * Added: protected `requiresRestart` method for extending classes.
   * Added: `setMainScript` method for applications that change the working directory.

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -63,7 +63,7 @@ class EnvironmentTest extends BaseTestCase
      *
      * @param callable $iniFunc IniHelper method to use
      * @param mixed $scandir Initial value for PHP_INI_SCAN_DIR
-     * @param string $expected The required PHP_INI_SCAN_DIR value
+     * @param mixed $expected The required PHP_INI_SCAN_DIR value
      *
      * @dataProvider scanDirProvider
      */
@@ -91,7 +91,8 @@ class EnvironmentTest extends BaseTestCase
 
     /**
      * Tests that PHP_INI_SCAN_DIR is restored to its original value after the
-     * process has been restarted.
+     * process has been restarted. Also tests that getRestartSettings reports
+     * correct values.
      *
      * @param callable $iniFunc IniHelper method to use
      * @param mixed $scandir Initial value for PHP_INI_SCAN_DIR
@@ -110,11 +111,20 @@ class EnvironmentTest extends BaseTestCase
         $this->checkRestart($xdebug);
         $this->assertSame($scandir, getenv('PHP_INI_SCAN_DIR'));
 
+        // Check that $_SERVER has been updated
         if (false !== $scandir) {
             $this->assertSame($scandir, $_SERVER['PHP_INI_SCAN_DIR']);
         } else {
             $this->assertSame(false, isset($_SERVER['PHP_INI_SCAN_DIR']));
         }
+
+        // Check that restart settings reports original scan dir
+        $settings = CoreMock::getRestartSettings();
+        $this->assertSame($scandir, $settings['scanDir']);
+
+        // Check that restart settings reports scannedInis
+        $scannedInis = $iniFunc === 'setScannedInis';
+        $this->assertSame($scannedInis, $settings['scannedInis']);
     }
 
     private function setScanDir($value)

--- a/tests/Helpers/BaseTestCase.php
+++ b/tests/Helpers/BaseTestCase.php
@@ -12,6 +12,7 @@
 namespace Composer\XdebugHandler\Helpers;
 
 use Composer\XdebugHandler\Mocks\CoreMock;
+use Composer\XdebugHandler\XdebugHandler;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -28,6 +29,7 @@ abstract class BaseTestCase extends TestCase
         CoreMock::ALLOW_XDEBUG,
         CoreMock::ORIGINAL_INIS,
         'PHP_INI_SCAN_DIR',
+        XdebugHandler::RESTART_SETTINGS,
     );
 
     /**
@@ -85,9 +87,6 @@ abstract class BaseTestCase extends TestCase
         // We must have been restarted
         $this->assertTrue($xdebug->restarted);
 
-        // We must be in a restarted process
-        $this->assertTrue(CoreMock::inRestartedProcess());
-
         // Env ALLOW_XDEBUG must be unset
         $this->assertSame(false, getenv(CoreMock::ALLOW_XDEBUG));
         $this->assertSame(false, isset($_SERVER[CoreMock::ALLOW_XDEBUG]));
@@ -103,7 +102,14 @@ abstract class BaseTestCase extends TestCase
             $version = CoreMock::TEST_VERSION;
         }
 
-        $this->assertSame($version, CoreMock::getSkippedVersion());
+        $this->assertSame($version, $xdebug::getSkippedVersion());
+
+        // Env RESTART_SETTINGS must be set and be a string
+        $this->assertInternalType('string', getenv(CoreMock::RESTART_SETTINGS));
+        $this->assertSame(true, isset($_SERVER[CoreMock::RESTART_SETTINGS]));
+
+        // Restart settings must be an array
+        $this->assertInternalType('array', $xdebug::getRestartSettings());
     }
 
     /**
@@ -116,14 +122,18 @@ abstract class BaseTestCase extends TestCase
         // We must not have been restarted
         $this->assertFalse($xdebug->restarted);
 
-        // We must not be in a restarted process
-        $this->assertFalse(CoreMock::inRestartedProcess());
-
         // Env ORIGINAL_INIS must not be set
         $this->assertSame(false, getenv(CoreMock::ORIGINAL_INIS));
+        $this->assertSame(false, isset($_SERVER[CoreMock::ORIGINAL_INIS]));
 
         // Skipped version must be an empty string
-        $class = get_class($xdebug);
-        $this->assertSame('', $class::getSkippedVersion());
+        $this->assertSame('', $xdebug::getSkippedVersion());
+
+        // Env RESTART_SETTINGS must not be set
+        $this->assertSame(false, getenv(CoreMock::RESTART_SETTINGS));
+        $this->assertSame(false, isset($_SERVER[CoreMock::RESTART_SETTINGS]));
+
+        // Restart settings must be null
+        $this->assertNull($xdebug::getRestartSettings());
     }
 }

--- a/tests/Mocks/CoreMock.php
+++ b/tests/Mocks/CoreMock.php
@@ -79,7 +79,6 @@ class CoreMock extends XdebugHandler
         $prop->setAccessible(true);
         $prop->setValue($this, null);
 
-
         // Ensure static private inRestart is unset
         $prop = $this->refClass->getProperty('inRestart');
         $prop->setAccessible(true);

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of composer/xdebug-handler.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Composer\XdebugHandler;
+
+use Composer\XdebugHandler\Helpers\BaseTestCase;
+use Composer\XdebugHandler\Mocks\CoreMock;
+
+/**
+ * We use PHP_BINARY which only became available in PHP 5.4
+ *
+ * @requires PHP 5.4
+ */
+class SettingsTest extends BaseTestCase
+{
+    /**
+     * Tests that the settings returned from getRestartSettings are correctly
+     * formatted.
+     *
+     * Other tests are performed in BaseTestCase checks, and the EnvironmentTest
+     * method testScanDirAfterRestart.
+     */
+    public function testGetRestartSettings()
+    {
+        $settings = $this->getRestartSettings();
+
+        $this->assertInternalType('string', $settings['tmpIni']);
+        $this->assertInternalType('boolean', $settings['scannedInis']);
+        // Note scanDir is checked specifically in Environment tests
+        $this->assertArrayHasKey('scanDir', $settings);
+        $this->assertInternalType('array', $settings['inis']);
+        $this->assertInternalType('string', $settings['skipped']);
+    }
+
+    /**
+     * Tests that a call with existing restart settings updates the current
+     * settings.
+     */
+    public function testSyncSettings()
+    {
+        // Create the settings in the environment
+        $this->getRestartSettings();
+
+        // Unset env ORIGINAL_INIS to mock a call by a different application
+        putenv(CoreMock::ORIGINAL_INIS);
+        unset($_SERVER[CoreMock::ORIGINAL_INIS]);
+
+        // Mock not loaded ($inRestart and $skipped statics are unset)
+        $loaded = false;
+        $xdebug = CoreMock::createAndCheck($loaded);
+
+        // Env ORIGINAL_INIS must be set and be a string
+        $this->assertInternalType('string', getenv(CoreMock::ORIGINAL_INIS));
+        $this->assertSame(true, isset($_SERVER[CoreMock::ORIGINAL_INIS]));
+
+        // Skipped version must be set
+        $this->assertSame(CoreMock::TEST_VERSION, $xdebug::getSkippedVersion());
+    }
+
+    /**
+     * Returns restart settings from a mocked restart.
+     */
+    private function getRestartSettings()
+    {
+        $loaded = true;
+        $xdebug = CoreMock::createAndCheck($loaded);
+        return CoreMock::getRestartSettings();
+    }
+}


### PR DESCRIPTION
Calling a PHP process from a restarted process is no different from calling it normally, except that xdebug will be loaded in that process. Of course if the process implements xdebug-handler, that process will also be restarted.

This PR stores settings in the environment after a restart, and provides a method to retrieve them.

```php

$settings = XdebugHandler::getRestartSettings();

/**
 * $settings: array (if the current process was restarted,
 * or called with the settings from an existing restart), or null
 *
 *    'tmpIni'      => the temporary ini file used in the restart (string)
 *    'scannedInis' => if there were any scanned inis (bool)
 *    'scanDir'     => the original PHP_INI_SCAN_DIR value (false|string)
 *    'inis'        => the original inis from getAllIniFiles (array)
 *    'skipped'     => the skipped version from getSkippedVersion (string)
 */
```

This allows an application to call a PHP process with the same settings that were used in a restart:

* If `scannedInis` is true, set `PHP_INI_SCAN_DIR` to an empty string.
* Add `tmpIni`to the command-line with the `-c` option.
* Run the process.
    * If it implements xdebug-handler, `PHP_INI_SCAN_DIR` is restored to its original value where necessary.
* If `PHP_INI_SCAN_DIR` was changed, restore it using `scanDir`.

Therefore an application can safely spawn itself, or other scripts that it controls, or other applications that implement xdebug-handler. 