### PR TITLE
Make ctype extension optional

### DIFF
--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -434,14 +434,31 @@ class XdebugHandler
 
             if (!isset($iniConfig[$name]) || $iniConfig[$name] !== $value) {
                 // Based on main -d option handling in php-src/sapi/cli/php_cli.c
-                if ($value && !ctype_alnum($value)) {
+                if ($value && !$this->hasAlphanumericCharsOnly($value)) {
                     $value = '"'.str_replace('"', '\\"', $value).'"';
                 }
+
                 $content .= $name.'='.$value.PHP_EOL;
             }
         }
 
         return $content;
+    }
+
+    /**
+     * Check that value contains letters and digits only.
+     *
+     * @param string $value
+     *
+     * @return bool
+     */
+    private function hasAlphanumericCharsOnly($value)
+    {
+        if (extension_loaded('ctype')) {
+            return ctype_alnum($value);
+        }
+
+        return !preg_match('/[^A-Za-z0-9]+/', $value);
     }
 
     /**


### PR DESCRIPTION
When we did some tests in Infection we found that the xdebug-handler has dependency on the `ctype` extension and some of our users may not have this extension.

So this PR does this extension optional. IniFilesTest covers this case.

Reference: https://github.com/infection/infection/pull/263#issuecomment-381012052