### PR TITLE
Use command-line option to suppress ini scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+  * Added: `PHPRC` original value to restart stettings, for use in a restarted process.
+  * Changed: internal procedure to disable ini-scanning, using `-n` command-line option.
   * Fixed: improved handling when checking main script.
   * Fixed: handling for standard input, that never actually did anything.
   * Fixed: fatal error when ctype extension is not available.

--- a/tests/Helpers/BaseTestCase.php
+++ b/tests/Helpers/BaseTestCase.php
@@ -29,6 +29,7 @@ abstract class BaseTestCase extends TestCase
         CoreMock::ALLOW_XDEBUG,
         CoreMock::ORIGINAL_INIS,
         'PHP_INI_SCAN_DIR',
+        'PHPRC',
         XdebugHandler::RESTART_SETTINGS,
     );
 

--- a/tests/Helpers/EnvHelper.php
+++ b/tests/Helpers/EnvHelper.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of composer/xdebug-handler.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Composer\XdebugHandler\Helpers;
+
+/**
+ * This helper class provides a central data provider that uses IniHelper to
+ * mock environment settings.
+ */
+class EnvHelper
+{
+    /**
+     * Mock the environment
+     *
+     * @param callable $iniFunc IniHelper method to use
+     * @param mixed $scanDir Initial value for PHP_INI_SCAN_DIR
+     * @param mixed $phprc Initial value for PHPRC
+     *
+     * @return IniHelper
+     */
+    public static function setInis($iniFunc, $scanDir, $phprc)
+    {
+        $ini = new IniHelper(array($scanDir, $phprc));
+        call_user_func(array($ini, $iniFunc));
+
+        return $ini;
+    }
+
+    public static function dataProvider()
+    {
+        $ini = new IniHelper();
+        $loaded = $ini->getLoadedIni();
+        $scanDir = $ini->getScanDir();
+
+        // $iniFunc, $scanDir, $phprc
+        return array(
+            'loaded false myini' => array('setLoadedIni', false, '/my.ini'),
+            'loaded empty false' => array('setLoadedIni', '', false),
+            'scanned false file' => array('setScannedInis', false, $loaded),
+            'scanned dir false' => array('setScannedInis', $scanDir, false),
+        );
+    }
+
+    public static function dataProviderEx()
+    {
+        // $iniFunc, $scanDir, $phprc, $standard
+        $data = self::dataProvider();
+        $result = array();
+
+        foreach ($data as $test => $params) {
+            $result[$test.' standard'] = array_merge($params, array(true));
+            $result[$test.' persistent'] = array_merge($params, array(false));
+        }
+
+        return $result;
+    }
+}

--- a/tests/Helpers/IniHelper.php
+++ b/tests/Helpers/IniHelper.php
@@ -26,7 +26,7 @@ class IniHelper
 
     /**
      * envOptions is an array of additional environment values to set,
-     * comprising: [PHP_INI_SCAN_DIR]
+     * comprising: [PHP_INI_SCAN_DIR, optional PHPRC]
      *
      * @param mixed $envOptions
      */
@@ -81,6 +81,11 @@ class IniHelper
         return $this->files;
     }
 
+    public function hasScannedInis()
+    {
+        return count($this->files) > 1;
+    }
+
     public function getLoadedIni()
     {
         return $this->loadedIni;
@@ -100,7 +105,13 @@ class IniHelper
 
         if ($options) {
             $scanDir = array_shift($options);
+            $phprc = array_shift($options);
+
             $this->setEnv('PHP_INI_SCAN_DIR', $scanDir);
+
+            if (null !== $phprc) {
+                $this->setEnv('PHPRC', $phprc);
+            }
         }
     }
 

--- a/tests/RestartTest.php
+++ b/tests/RestartTest.php
@@ -36,6 +36,9 @@ class RestartTest extends BaseTestCase
         $xdebug = PartialMock::createAndCheck($loaded);
         $command = $xdebug->getCommand();
 
+        $n = Process::escape('-n');
+        $this->assertContains(" {$n} ", " {$command} ");
+
         $c = Process::escape('-c');
         $tmpIni = Process::escape($xdebug->getTmpIni());
         $this->assertContains(" {$c} {$tmpIni} ", " {$command} ");


### PR DESCRIPTION
When specifying an ini file on the command-line, there are two ways to
stop PHP scanning for additional ini files - either by setting
`PHP_INI_SCAN_DIR` to an empty string or using the `-n` option. Neither
are documented as doing this in the PHP manual.

xdebug-handler always used the first method (and restored the
environment in the restart). Later, after debugging through the PHP
source code, it became apparent that another solution was to use `-n`,
but there seemed little point in changing something that was already
working at that time.

Note that `main/php_ini.c` is quite explicit about this usage, with the
following code comment, from August 2008:

    If SAPI does not want to ignore all ini files OR an overriding
    file/path is given. This allows disabling scanning for ini files in
    the PHP_CONFIG_FILE_SCAN_DIR but still load an optional ini file.

Switching to this method makes it easier for developers to use the
restart settings to invoke a PHP sub-process, because the environment is
'clean' in that sub-process. This change is internal and has no affect
on current usage.