### PR TITLE
Add helper class to manage PHP sub-processes

### DIFF
--- a/src/PhpConfig.php
+++ b/src/PhpConfig.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of composer/xdebug-handler.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Composer\XdebugHandler;
+
+/**
+ * @author John Stevenson <john-stevenson@blueyonder.co.uk>
+ */
+class PhpConfig
+{
+    /**
+     * Use the original PHP configuration
+     *
+     * @return array PHP cli options
+     */
+    public function useOriginal()
+    {
+        $this->getDataAndReset();
+        return array();
+    }
+
+    /**
+     * Use standard restart settings
+     *
+     * @return array PHP cli options
+     */
+    public function useStandard()
+    {
+        if ($data = $this->getDataAndReset()) {
+            return array('-n', '-c', $data['tmpIni']);
+        }
+
+        return array();
+    }
+
+    /**
+     * Use environment variables to persist settings
+     *
+     * @return array PHP cli options
+     */
+    public function usePersistent()
+    {
+        if ($data = $this->getDataAndReset()) {
+            Process::setEnv('PHPRC', $data['tmpIni']);
+            Process::setEnv('PHP_INI_SCAN_DIR', '');
+        }
+
+        return array();
+    }
+
+    /**
+     * Returns restart data if available and resets the environment
+     *
+     * @return array|null
+     */
+    private function getDataAndReset()
+    {
+        if ($data = XdebugHandler::getRestartSettings()) {
+            Process::setEnv('PHPRC', $data['phprc']);
+            Process::setEnv('PHP_INI_SCAN_DIR', $data['scanDir']);
+        }
+
+        return $data;
+    }
+}

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -76,7 +76,7 @@ class EnvironmentTest extends BaseTestCase
         PartialMock::createAndCheck($loaded, null, $settings);
 
         if (!$standard) {
-            //$scanDir = $ini->hasScannedInis() ? '' : $scanDir;
+            //$scanDir = '';
             //$phprc = $xdebug->getTmpIni();
         }
 

--- a/tests/Mocks/CoreMock.php
+++ b/tests/Mocks/CoreMock.php
@@ -120,6 +120,7 @@ class CoreMock extends XdebugHandler
             CoreMock::ALLOW_XDEBUG,
             CoreMock::ORIGINAL_INIS,
             'PHP_INI_SCAN_DIR',
+            'PHPRC',
         );
 
         foreach ($names as $name) {

--- a/tests/PhpConfigTest.php
+++ b/tests/PhpConfigTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of composer/xdebug-handler.
+ *
+ * (c) Composer <https://github.com/composer>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Composer\XdebugHandler;
+
+use Composer\XdebugHandler\Helpers\BaseTestCase;
+use Composer\XdebugHandler\Helpers\EnvHelper;
+use Composer\XdebugHandler\Mocks\CoreMock;
+
+/**
+ * We use PHP_BINARY which only became available in PHP 5.4
+ *
+ * @requires PHP 5.4
+ */
+class PhpConfigTest extends BaseTestCase
+{
+    /**
+     * Tests that the correct command-line options are returned.
+     *
+     * @param string $method PhpConfig method to call
+     * @param array $expected
+     * @dataProvider commandLineProvider
+     */
+    public function testCommandLineOptions($method, $expected)
+    {
+        $loaded = true;
+        CoreMock::createAndCheck($loaded);
+
+        $config = new PhpConfig();
+        $options = call_user_func(array($config, $method));
+
+        if ($method === 'useStandard') {
+            $data = CoreMock::getRestartSettings();
+            $expected[2] = $data['tmpIni'];
+        }
+
+        $this->assertSame($expected, $options);
+    }
+
+    public function commandLineProvider()
+    {
+        // $method, $expected
+        return array(
+            'original' => array('useOriginal', array()),
+            'standard' => array('useStandard', array('-n', '-c', '')),
+            'persistent'  => array('usePersistent', array()),
+        );
+    }
+
+    /**
+     * Tests that the environment is set correctly for each mode.
+     *
+     * @param callable $iniFunc IniHelper method to use
+     * @param mixed $scanDir Initial value for PHP_INI_SCAN_DIR
+     * @param $phprc Initial value for PHPRC
+     * @dataProvider environmentProvider
+     */
+    public function testEnvironment($iniFunc, $scanDir, $phprc)
+    {
+        $ini = EnvHelper::setInis($iniFunc, $scanDir, $phprc);
+
+        $loaded = true;
+        CoreMock::createAndCheck($loaded);
+
+        $config = new PhpConfig();
+        $data = CoreMock::getRestartSettings();
+
+        $tests = array('useOriginal', 'usePersistent', 'useStandard');
+
+        foreach ($tests as $method) {
+            call_user_func(array($config, $method));
+
+            if ($method === 'usePersistent') {
+                $expectedScanDir = '';
+                $expectedPhprc = $data['tmpIni'];
+            } else {
+                $expectedScanDir = $scanDir;
+                $expectedPhprc = $phprc;
+            }
+
+            $this->checkEnvironment($expectedScanDir, $expectedPhprc, $method);
+        }
+    }
+
+    public function environmentProvider()
+    {
+        return EnvHelper::dataProvider();
+    }
+
+    /**
+     * Checks the value of variables in the local environment and $_SERVER
+     *
+     * @param mixed $scanDir
+     * @param mixed $phprc
+     * @param string $name
+     */
+    private function checkEnvironment($scanDir, $phprc, $name)
+    {
+        $tests = array('PHP_INI_SCAN_DIR' => $scanDir, 'PHPRC' => $phprc);
+
+        foreach ($tests as $env => $value) {
+            $message = $name.' '.strtolower($env);
+            $this->assertSame($value, getenv($env), 'getenv '.$message);
+
+            if (false === $value) {
+                $this->assertSame($value, isset($_SERVER[$env]), '$_SERVER '.$message);
+            } else {
+                $this->assertSame($value, $_SERVER[$env], '$_SERVER '.$message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I originally thought that this should not be part of the main library, but it is a tiny class (it doesn't add much more than recently removed scan-dir code) which also makes it easier to explain the various sub-process strategies. 