### PR TITLE
Process::addColorOption when double dash is one of args

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ This optional value is added to the restart command-line and is needed to force 
 
 If the original command-line contains an argument that pattern-matches this value, for example `--no-ansi` `--colors=never`, then _$colorOption_ is ignored.
 
-Do not use this parameter if the input handler cannot cope with an option as the last argument.
-
 ## Advanced Usage
 ### How it works
 

--- a/src/Process.php
+++ b/src/Process.php
@@ -50,7 +50,14 @@ class Process
             return $args;
         }
 
-        $args[] = $colorOption;
+        $doubleDashIndex = array_search('--', $args, true);
+
+        if (false === $doubleDashIndex) {
+            $args[] = $colorOption;
+        } else {
+            array_splice($args, $doubleDashIndex, 0, $colorOption);
+        }
+
         return $args;
     }
 

--- a/tests/ColourOptionTest.php
+++ b/tests/ColourOptionTest.php
@@ -105,4 +105,12 @@ class ColorOptionTest extends TestCase
         $this->assertContains($colorOption, $result);
         $this->assertNotContains($existing, $result);
     }
+
+    public function testOptionIsProperlyAddedBeforeDoubleDash()
+    {
+        $args = array('script.php', '--option', '--', 'paramA', 'paramB');
+
+        $result = Process::addColorOption($args, '--ansi');
+        $this->assertSame('script.php --option --ansi -- paramA paramB', implode(' ', $result));
+    }
 }


### PR DESCRIPTION
We faced an issue when we tried to add colour option for command that is using double dash,
eg adding `--ansi` for `php-cs-fixer fix -v -- fileA.php fileB.php`

With current state, `--ansi` ends always as last place, thus after `--`, which won't work and:
- command won't be run with enforcing colour output
- command will get `--ansi` as position argument (and not option) and fail to handle it

More details at https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3901