### PR TITLE
Fix regression in Process::addColorOption

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ This optional value is added to the restart command-line and is needed to force 
 
 If the original command-line contains an argument that pattern-matches this value, for example `--no-ansi` `--colors=never`, then _$colorOption_ is ignored.
 
+If the pattern-match ends with =auto, for example `--colors=auto`, the argument is replaced by _$colorOption_. Otherwise it is added at either the end of the command-line, or preceeding a double-dash `--` delimiter.
+
 ## Advanced Usage
 ### How it works
 

--- a/src/Process.php
+++ b/src/Process.php
@@ -21,11 +21,11 @@ namespace Composer\XdebugHandler;
 class Process
 {
     /**
-     * Returns the process arguments, appending a color option if required
+     * Returns an array of parameters, including a color option if required
      *
      * A color option is needed because child process output is piped.
      *
-     * @param array $args Command line arguments
+     * @param array $args The script parameters
      * @param string $colorOption The long option to force color output
      *
      * @return array
@@ -39,8 +39,8 @@ class Process
         }
 
         if (isset($matches[2])) {
-            // Handle --color(s)= options. Note args[0] is the script name
-            if ($index = array_search($matches[2].'auto', $args)) {
+            // Handle --color(s)= options
+            if (false !== ($index = array_search($matches[2].'auto', $args))) {
                 $args[$index] = $colorOption;
                 return $args;
             } elseif (preg_grep('/^'.$matches[2].'/', $args)) {
@@ -50,12 +50,11 @@ class Process
             return $args;
         }
 
-        $doubleDashIndex = array_search('--', $args, true);
-
-        if (false === $doubleDashIndex) {
-            $args[] = $colorOption;
+        if (false !== ($index = array_search('--', $args))) {
+            // Position option before double-dash delimiter
+            array_splice($args, $index, 0, $colorOption);
         } else {
-            array_splice($args, $doubleDashIndex, 0, $colorOption);
+            $args[] = $colorOption;
         }
 
         return $args;

--- a/tests/ColourOptionTest.php
+++ b/tests/ColourOptionTest.php
@@ -24,20 +24,19 @@ class ColorOptionTest extends TestCase
      *
      * @dataProvider neededProvider
      */
-    public function testOptionNeeded($colorOption)
+    public function testOptionNeeded($args, $colorOption, $expected)
     {
-        $args = array('script.php', 'param');
-
         $result = Process::addColorOption($args, $colorOption);
-        $this->assertContains($colorOption, $result);
+        $this->assertSame($expected, implode(' ', $result));
     }
 
     public function neededProvider()
     {
-        // $colorOption
+        // $args, $colorOption, $expected
         return array(
-            'simple' => array('--xxx'),
-            'complex' => array('--xxx=yyy'),
+            'simple' => array(array('--option', 'param'), '--xxx', '--option param --xxx'),
+            'complex' => array(array('--option', 'param'), '--xxx=yyy', '--option param --xxx=yyy'),
+            'position' => array(array('--option', '--', 'param'), '--xxx', '--option --xxx -- param'),
         );
     }
 
@@ -49,8 +48,7 @@ class ColorOptionTest extends TestCase
      */
     public function testOptionNotNeeded($existing, $colorOption)
     {
-        $args = array('script.php', 'param');
-        $args[] = $existing;
+        $args = array($existing, '--option', 'param');
 
         $result = Process::addColorOption($args, $colorOption);
         $this->assertContains($existing, $result);
@@ -74,7 +72,7 @@ class ColorOptionTest extends TestCase
      */
     public function testOptionNotMatched($colorOption)
     {
-        $args = array('script.php', 'param');
+        $args = array('--option', 'param');
 
         $result = Process::addColorOption($args, $colorOption);
         $this->assertNotContains($colorOption, $result);
@@ -96,21 +94,10 @@ class ColorOptionTest extends TestCase
      */
     public function testOptionReplaced()
     {
-        $args = array('script.php', 'param');
-        $existing = '--xxx=auto';
+        $args = array('--xxx=auto', 'param');
         $colorOption = '--xxx=always';
-        $args[] = $existing;
 
         $result = Process::addColorOption($args, $colorOption);
-        $this->assertContains($colorOption, $result);
-        $this->assertNotContains($existing, $result);
-    }
-
-    public function testOptionIsProperlyAddedBeforeDoubleDash()
-    {
-        $args = array('script.php', '--option', '--', 'paramA', 'paramB');
-
-        $result = Process::addColorOption($args, '--ansi');
-        $this->assertSame('script.php --option --ansi -- paramA paramB', implode(' ', $result));
+        $this->assertSame('--xxx=always param', implode(' ', $result));
     }
 }


### PR DESCRIPTION
When the main script was removed from the array of arguments passed to
addColorOption, the searching logic was not updated to reflect
that zero might be returned as an array index.