### PR TITLE
Fix apc.mmap_file_mask being updated in tmp ini

### DIFF
--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -410,7 +410,9 @@ class XdebugHandler
 
         foreach ($loadedConfig as $name => $value) {
             // Value will either be null, string or array (HHVM only)
-            if (!is_string($value) || strpos($name, 'xdebug') === 0) {
+            if (!is_string($value)
+                || strpos($name, 'xdebug') === 0
+                || $name === 'apc.mmap_file_mask') {
                 continue;
             }
 


### PR DESCRIPTION
When the current ini settings are merged into the ini file content, a
setting will be added if it exists but doesn't match the current value.

In the case of apc.mmap_file_mask, the value is a template string that
is used by the system `mkstemp`, which PHP unfortunately updates to the
actual file being used. If this is added to the tmp ini, it causes
`mkstemp` to fail and a fatal error.