### PR TITLE
Check that php_ini_scanned_files() is functional

### DIFF
--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -276,6 +276,8 @@ class XdebugHandler
             $error = 'Unsupported SAPI: '.PHP_SAPI;
         } elseif (!defined('PHP_BINARY')) {
             $error = 'PHP version is too old: '.PHP_VERSION;
+        } elseif (!$this->checkScanDirConfig()) {
+            $error = 'PHP version does not report scanned inis: '.PHP_VERSION;
         } elseif (!$this->checkMainScript()) {
             $error = 'Unable to access main script: '.$this->script;
         } elseif (!$this->writeTmpIni($iniFiles)) {
@@ -485,5 +487,21 @@ class XdebugHandler
 
         self::$skipped = $settings['skipped'];
         $this->notify(Status::INFO, 'Process called with existing restart settings');
+    }
+
+    /**
+     * Returns true if there are scanned inis and PHP is able to report them
+     *
+     * php_ini_scanned_files will fail when PHP_CONFIG_FILE_SCAN_DIR is empty.
+     * Fixed in 7.1.13 and 7.2.1
+     *
+     * @return bool
+     */
+    private function checkScanDirConfig()
+    {
+        return !(getenv('PHP_INI_SCAN_DIR')
+            && !PHP_CONFIG_FILE_SCAN_DIR
+            && (PHP_VERSION_ID < 70113
+            || PHP_VERSION_ID === 70200));
     }
 }

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -34,6 +34,10 @@ class EnvironmentTest extends BaseTestCase
      */
     public function testEnvAllowBeforeRestart($iniFunc, $scanDir, $phprc)
     {
+        if ($message = EnvHelper::shouldSkipTest($scanDir)) {
+            $this->markTestSkipped($message);
+        }
+
         $ini = EnvHelper::setInis($iniFunc, $scanDir, $phprc);
         $loaded = true;
 

--- a/tests/Helpers/EnvHelper.php
+++ b/tests/Helpers/EnvHelper.php
@@ -48,4 +48,42 @@ class EnvHelper
             'scanned dir false' => array('setScannedInis', $scanDir, false),
         );
     }
+
+    /**
+     * Checks if php_ini_scanned_files is supported.
+     *
+     * The process will not be restarted if there are scanned inis but PHP
+     * is unable to list them. See https://bugs.php.net/73124
+     *
+     * This method tests the behaviour of XdebugHandler::checkScanDirConfig by
+     * checking each requirement separately.
+     *
+     * @param mixed $scanDir Initial value for PHP_INI_SCAN_DIR
+     *
+     * @return null|string The skip message
+     */
+    public static function shouldSkipTest($scanDir)
+    {
+        // Not relevant if no scan dir or it has been overriden
+        if ($scanDir === false || $scanDir === '') {
+            return;
+        }
+
+        // Not relevant if --with-config-file-scan-dir was used
+        if (PHP_CONFIG_FILE_SCAN_DIR !== '') {
+            return;
+        }
+
+        // Bug fixed in 7.1.13
+        if (PHP_VERSION_ID >= 70113 && PHP_VERSION_ID < 70200) {
+            return;
+        }
+
+        // Bug fixed in 7.2.1
+        if (PHP_VERSION_ID >= 70201) {
+            return;
+        }
+
+        return 'php_ini_scanned_files not functional on '.PHP_VERSION;
+    }
 }

--- a/tests/PhpConfigTest.php
+++ b/tests/PhpConfigTest.php
@@ -65,6 +65,10 @@ class PhpConfigTest extends BaseTestCase
      */
     public function testEnvironment($iniFunc, $scanDir, $phprc)
     {
+        if ($message = EnvHelper::shouldSkipTest($scanDir)) {
+            $this->markTestSkipped($message);
+        }
+
         $ini = EnvHelper::setInis($iniFunc, $scanDir, $phprc);
 
         $loaded = true;

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -32,6 +32,10 @@ class SettingsTest extends BaseTestCase
      */
     public function testGetRestartSettings($iniFunc, $scanDir, $phprc)
     {
+        if ($message = EnvHelper::shouldSkipTest($scanDir)) {
+            $this->markTestSkipped($message);
+        }
+
         $ini = EnvHelper::setInis($iniFunc, $scanDir, $phprc);
 
         $loaded = true;


### PR DESCRIPTION
If the PHP build does not set a --with-config-file-scan-dir value (on
Windows mainly), `php_ini_scanned_files` always fails. This is now
fixed in 7.1.13 and 7.2.1. See https://bugs.php.net/73124

When xdebug-handler used the environment to suppress ini-scanning, this
did not matter - although xdebug may not have been disabled. But now
that command-line options are used, configuration from the scanned inis
will not be used in the restart.

This fix ensures that the restart fails in such a situation, with an
appropriate status message.