### PR TITLE
Do not restart if an ini file is inaccessible

### DIFF
--- a/tests/Helpers/IniHelper.php
+++ b/tests/Helpers/IniHelper.php
@@ -76,6 +76,18 @@ class IniHelper
         $this->setEnvironment();
     }
 
+    public function setInaccessibleIni()
+    {
+        $this->files = array(
+            '',
+            $this->scanDir.DIRECTORY_SEPARATOR.'scan-one.ini',
+            $this->scanDir.DIRECTORY_SEPARATOR.'scan-two.ini',
+            $this->scanDir.DIRECTORY_SEPARATOR.'scan-missing.ini',
+        );
+
+        $this->setEnvironment();
+    }
+
     public function getIniFiles()
     {
         return $this->files;

--- a/tests/IniFilesTest.php
+++ b/tests/IniFilesTest.php
@@ -125,6 +125,23 @@ class IniFilesTest extends BaseTestCase
     }
 
     /**
+     * Tests that an inaccessible ini file causes the restart to fail
+     *
+     */
+    public function testInaccessbleIni()
+    {
+        $ini = new IniHelper();
+        $ini->setInaccessibleIni();
+
+        $loaded = true;
+        $xdebug = CoreMock::createAndCheck($loaded);
+
+        // We need to remove the mock inis from the environment
+        Process::setEnv(CoreMock::ORIGINAL_INIS, false);
+        $this->checkNoRestart($xdebug);
+    }
+
+    /**
      * Common method to get mocked tmp ini content
      *
      * @param mixed $xdebug


### PR DESCRIPTION
If an ini file is not readable (file permissions, open_basedir setting,
system lock etc) then PHP would show a warning and xdebug-handler would
carry on regardless. In retrospect this strategy seems flawed because
the restarted process will not receive all its intended settings.

This PR changes this behaviour by disabling PHP error output and simply
not restarting. Error output is also disabled when calling tempnam.

Prompted by https://github.com/composer/composer/issues/7807