### PR TITLE
Update $_ENV if it was populated

### DIFF
--- a/src/Process.php
+++ b/src/Process.php
@@ -156,7 +156,7 @@ class Process
             $_SERVER[$name] = $value;
         }
         
-        if (false !== strpos((string) ini_get('variables_order'), 'E')) {
+        if (false !== stripos((string) ini_get('variables_order'), 'E')) {
             if ($unset) {
                 unset($_ENV[$name]);
             } else {

--- a/src/Process.php
+++ b/src/Process.php
@@ -156,7 +156,7 @@ class Process
             $_SERVER[$name] = $value;
         }
         
-        if (false !== strpos(ini_get('variables_order'), 'E')) {
+        if (false !== strpos((string) ini_get('variables_order'), 'E')) {
             if ($unset) {
                 unset($_ENV[$name]);
             } else {

--- a/src/Process.php
+++ b/src/Process.php
@@ -155,6 +155,15 @@ class Process
         } else {
             $_SERVER[$name] = $value;
         }
+        
+        if (false !== strpos(ini_get('variables_order'), 'E')) {
+            if ($unset) {
+                unset($_ENV[$name]);
+            } else {
+                $_ENV[$name] = $value;
+            }
+        }
+        
         return true;
     }
 }


### PR DESCRIPTION
Update `$_ENV` if it was populated to reflect environment changes. Say, Symfony's Process will happily import anything from `$_ENV`, but if we only update the global environment (remove some variables), it'll have no effect on `$_ENV` if it was populated before. Which happens when `variables_order` contains an `E`.

Please let me know if this makes any sense.