### PR TITLE
XdebugHandler: check if uopz isn't disabled in ini

### DIFF
--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -550,7 +550,7 @@ class XdebugHandler
             return false;
         }
 
-        if (extension_loaded('uopz')) {
+        if (extension_loaded('uopz') && !ini_get('uopz.disable')) {
             // uopz works at opcode level and disables exit calls
             if (function_exists('uopz_allow_exit')) {
                 @uopz_allow_exit(true);


### PR DESCRIPTION
Make sure `uopz` isn't disabled in ini, prevents fatals like:

```
Fatal error: Uncaught RuntimeException: uopz is disabled by configuration (uopz.disable) in ...
```

Ref: https://github.com/krakjoe/uopz/blob/a45fcaa5177ece9c2d83d79086f089b7f1c9d3dd/uopz.c#L45

Thank you!