### PR TITLE
Fix: Xdebug vs xdebug

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![license](https://img.shields.io/github/license/composer/xdebug-handler.svg)
 ![php](https://img.shields.io/packagist/php-v/composer/xdebug-handler.svg?colorB=8892BF&label=php)
 
-Restart a CLI process without loading the xdebug extension.
+Restart a CLI process without loading the Xdebug extension.
 
 Originally written as part of [composer/composer](https://github.com/composer/composer),
 now extracted and made available as a stand-alone library.
@@ -37,7 +37,7 @@ The constructor takes two parameters:
 #### _$envPrefix_
 This is used to create distinct environment variables and is upper-cased and prepended to default base values. The above example enables the use of:
 
-- `MYAPP_ALLOW_XDEBUG=1` to override automatic restart and allow xdebug
+- `MYAPP_ALLOW_XDEBUG=1` to override automatic restart and allow Xdebug
 - `MYAPP_ORIGINAL_INIS` to obtain ini file locations in a restarted process
 
 #### _$colorOption_
@@ -59,7 +59,7 @@ If the pattern match ends with `=auto` (for example `--colors=auto`), the argume
 
 ### How it works
 
-A temporary ini file is created from the loaded (and scanned) ini files, with any references to the xdebug extension commented out. Current ini settings are merged, so that most ini settings made on the command-line or by the application are included (see [Limitations](#limitations))
+A temporary ini file is created from the loaded (and scanned) ini files, with any references to the Xdebug extension commented out. Current ini settings are merged, so that most ini settings made on the command-line or by the application are included (see [Limitations](#limitations))
 
 * `MYAPP_ALLOW_XDEBUG` is set with internal data to flag and use in the restart.
 * The command-line and environment are [configured](#process-configuration) for the restart.
@@ -74,7 +74,7 @@ There are a few things to be aware of when running inside a restarted process.
 
 * Extensions set on the command-line will not be loaded.
 * Ini file locations will be reported as per the restart - see [getAllIniFiles()](#getallinifiles).
-* Php sub-processes may be loaded with xdebug enabled - see [Process configuration](#process-configuration).
+* Php sub-processes may be loaded with Xdebug enabled - see [Process configuration](#process-configuration).
 
 ### Helper methods
 These static methods provide information from the current process, regardless of whether it has been restarted or not.
@@ -115,7 +115,7 @@ $settings = XdebugHandler::getRestartSettings();
 ```
 
 #### _getSkippedVersion()_
-Returns the xdebug version string that was skipped by the restart, or an empty value if there was no restart (or xdebug is still loaded, perhaps by an extending class restarting for a reason other than removing xdebug).
+Returns the Xdebug version string that was skipped by the restart, or an empty value if there was no restart (or Xdebug is still loaded, perhaps by an extending class restarting for a reason other than removing Xdebug).
 
 ```php
 use Composer\XdebugHandler\XdebugHandler;
@@ -133,12 +133,12 @@ Enables the output of status messages to an external PSR3 logger. All messages a
 ```
 // Restart overridden
 DEBUG    Checking MYAPP_ALLOW_XDEBUG
-DEBUG    The xdebug extension is loaded (2.5.0)
+DEBUG    The Xdebug extension is loaded (2.5.0)
 DEBUG    No restart (MYAPP_ALLOW_XDEBUG=1)
 
 // Failed restart
 DEBUG    Checking MYAPP_ALLOW_XDEBUG
-DEBUG    The xdebug extension is loaded (2.5.0)
+DEBUG    The Xdebug extension is loaded (2.5.0)
 WARNING  No restart (Unable to create temp ini file at: ...)
 ```
 
@@ -148,11 +148,11 @@ Status messages can also be output with `XDEBUG_HANDLER_DEBUG`. See [Troubleshoo
 Sets the location of the main script to run in the restart. This is only needed in more esoteric use-cases, or if the `argv[0]` location is inaccessible. The script name `--` is supported for standard input.
 
 #### _setPersistent()_
-Configures the restart using [persistent settings](#persistent-settings), so that xdebug is not loaded in any sub-process.
+Configures the restart using [persistent settings](#persistent-settings), so that Xdebug is not loaded in any sub-process.
 
-Use this method if your application invokes one or more PHP sub-process and the xdebug extension is not needed. This avoids the overhead of implementing specific [sub-process](#sub-processes) strategies.
+Use this method if your application invokes one or more PHP sub-process and the Xdebug extension is not needed. This avoids the overhead of implementing specific [sub-process](#sub-processes) strategies.
 
-Alternatively, this method can be used to set up a default _xdebug-free_ environment which can be changed if a sub-process requires xdebug, then restored afterwards:
+Alternatively, this method can be used to set up a default _Xdebug-free_ environment which can be changed if a sub-process requires Xdebug, then restored afterwards:
 
 ```php
 function SubProcessWithXdebug()
@@ -162,45 +162,45 @@ function SubProcessWithXdebug()
     # Set the environment to the original configuration
     $phpConfig->useOriginal();
 
-    # run the process with xdebug loaded
+    # run the process with Xdebug loaded
     ...
 
-    # Restore xdebug-free environment
+    # Restore Xdebug-free environment
     $phpConfig->usePersistent();
 }
 ```
 
 ### Process configuration
-The library offers two strategies to invoke a new PHP process without loading xdebug, using either _standard_ or _persistent_ settings. Note that this is only important if the application calls a PHP sub-process.
+The library offers two strategies to invoke a new PHP process without loading Xdebug, using either _standard_ or _persistent_ settings. Note that this is only important if the application calls a PHP sub-process.
 
 #### Standard settings
-Uses command-line options to remove xdebug from the new process only.
+Uses command-line options to remove Xdebug from the new process only.
 
 * The -n option is added to the command-line. This tells PHP not to scan for additional inis.
 * The temporary ini is added to the command-line with the -c option.
 
->_If the new process calls a PHP sub-process, xdebug will be loaded in that sub-process (unless it implements xdebug-handler, in which case there will be another restart)._
+>_If the new process calls a PHP sub-process, Xdebug will be loaded in that sub-process (unless it implements xdebug-handler, in which case there will be another restart)._
 
 This is the default strategy used in the restart.
 
 #### Persistent settings
-Uses environment variables to remove xdebug from the new process and persist these settings to any sub-process.
+Uses environment variables to remove Xdebug from the new process and persist these settings to any sub-process.
 
 * `PHP_INI_SCAN_DIR` is set to an empty string. This tells PHP not to scan for additional inis.
 * `PHPRC` is set to the temporary ini.
 
->_If the new process calls a PHP sub-process, xdebug will not be loaded in that sub-process._
+>_If the new process calls a PHP sub-process, Xdebug will not be loaded in that sub-process._
 
 This strategy can be used in the restart by calling [setPersistent()](#setpersistent).
 
 #### Sub-processes
-The `PhpConfig` helper class makes it easy to invoke a PHP sub-process (with or without xdebug loaded), regardless of whether there has been a restart.
+The `PhpConfig` helper class makes it easy to invoke a PHP sub-process (with or without Xdebug loaded), regardless of whether there has been a restart.
 
 Each of its methods returns an array of PHP options (to add to the command-line) and sets up the environment for the required strategy. The [getRestartSettings()](#getrestartsettings) method is used internally.
 
-* `useOriginal()` - xdebug will be loaded in the new process.
-* `useStandard()` - xdebug will **not** be loaded in the new process - see [standard settings](#standard-settings).
-* `userPersistent()` - xdebug will **not** be loaded in the new process - see [persistent settings](#persistent-settings)
+* `useOriginal()` - Xdebug will be loaded in the new process.
+* `useStandard()` - Xdebug will **not** be loaded in the new process - see [standard settings](#standard-settings).
+* `userPersistent()` - Xdebug will **not** be loaded in the new process - see [persistent settings](#persistent-settings)
 
 If there was no restart, an empty options array is returned and the environment is not changed.
 
@@ -233,7 +233,7 @@ The following environment settings can be used to troubleshoot unexpected behavi
 The API is defined by classes and their accessible elements that are not annotated as @internal. The main class has two protected methods that can be overridden to provide additional functionality:
 
 #### _requiresRestart($isLoaded)_
-By default the process will restart if xdebug is loaded. Extending this method allows an application to decide, by returning a boolean (or equivalent) value. It is only called if `MYAPP_ALLOW_XDEBUG` is empty, so it will not be called in the restarted process (where this variable contains internal data), or if the restart has been overridden.
+By default the process will restart if Xdebug is loaded. Extending this method allows an application to decide, by returning a boolean (or equivalent) value. It is only called if `MYAPP_ALLOW_XDEBUG` is empty, so it will not be called in the restarted process (where this variable contains internal data), or if the restart has been overridden.
 
 Note that the [setMainScript()](#setmainscriptscript) and [setPersistent()](#setpersistent) setters can be used here, if required.
 
@@ -249,7 +249,7 @@ This example demonstrates two ways to extend basic functionality:
 
 * To avoid the overhead of spinning up a new process, the restart is skipped if a simple help command is requested.
 
-* The application needs write-access to phar files, so it will force a restart if `phar.readonly` is set (regardless of whether xdebug is loaded) and change this value in the temporary ini file.
+* The application needs write-access to phar files, so it will force a restart if `phar.readonly` is set (regardless of whether Xdebug is loaded) and change this value in the temporary ini file.
 
 ```php
 use Composer\XdebugHandler\XdebugHandler;
@@ -262,7 +262,7 @@ class MyRestarter extends XdebugHandler
     protected function requiresRestart($isLoaded)
     {
         if (Command::isHelp()) {
-            # No need to disable xdebug for this
+            # No need to disable Xdebug for this
             return false;
         }
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "composer/xdebug-handler",
-    "description": "Restarts a process without xdebug.",
+    "description": "Restarts a process without Xdebug.",
     "type": "library",
     "license": "MIT",
     "keywords": [

--- a/src/Status.php
+++ b/src/Status.php
@@ -151,13 +151,13 @@ class Status
     }
 
     /**
-     * Returns the xdebug status and version
+     * Returns the Xdebug status and version
      *
      * @return string
      */
     private function getLoadedMessage()
     {
         $loaded = $this->loaded ? sprintf('loaded (%s)', $this->loaded) : 'not loaded';
-        return 'The xdebug extension is '.$loaded;
+        return 'The Xdebug extension is '.$loaded;
     }
 }

--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -104,7 +104,7 @@ class XdebugHandler
     }
 
     /**
-     * Persist the settings to keep xdebug out of sub-processes
+     * Persist the settings to keep Xdebug out of sub-processes
      *
      * @return $this
      */
@@ -115,7 +115,7 @@ class XdebugHandler
     }
 
     /**
-     * Checks if xdebug is loaded and the process needs to be restarted
+     * Checks if Xdebug is loaded and the process needs to be restarted
      *
      * This behaviour can be disabled by setting the MYAPP_ALLOW_XDEBUG
      * environment variable to 1. This variable is used internally so that
@@ -146,7 +146,7 @@ class XdebugHandler
             self::$inRestart = true;
 
             if (!$this->loaded) {
-                // Skipped version is only set if xdebug is not loaded
+                // Skipped version is only set if Xdebug is not loaded
                 self::$skipped = $envArgs[1];
             }
 
@@ -218,7 +218,7 @@ class XdebugHandler
     }
 
     /**
-     * Returns the xdebug version that triggered a successful restart
+     * Returns the Xdebug version that triggered a successful restart
      *
      * @return string
      */
@@ -228,9 +228,9 @@ class XdebugHandler
     }
 
     /**
-     * Returns true if xdebug is loaded, or as directed by an extending class
+     * Returns true if Xdebug is loaded, or as directed by an extending class
      *
-     * @param bool $isLoaded Whether xdebug is loaded
+     * @param bool $isLoaded Whether Xdebug is loaded
      *
      * @return bool
      */

--- a/tests/IniFilesTest.php
+++ b/tests/IniFilesTest.php
@@ -55,7 +55,7 @@ class IniFilesTest extends BaseTestCase
     }
 
     /**
-     * Tests that the tmpIni file is created, contains disabled xdebug
+     * Tests that the tmpIni file is created, contains disabled Xdebug
      * entries and is correctly end-of-line terminated.
      *
      * @param callable $iniFunc IniHelper method to use

--- a/tests/Mocks/CoreMock.php
+++ b/tests/Mocks/CoreMock.php
@@ -20,7 +20,7 @@ use Composer\XdebugHandler\XdebugHandler;
  * getProperty method that accesses private properties. Extend this class to
  * provide further capabilities.
  *
- * It does not matter whether xdebug is loaded, because this value is overriden
+ * It does not matter whether Xdebug is loaded, because this value is overriden
  * in the constructor.
  *
  * The tmpIni file is deleted in the destructor.

--- a/tests/Mocks/FailMock.php
+++ b/tests/Mocks/FailMock.php
@@ -12,7 +12,7 @@
 namespace Composer\XdebugHandler\Mocks;
 
 /**
- * FailMock provides its own restart method that mocks a restart with xdebug
+ * FailMock provides its own restart method that mocks a restart with Xdebug
  * still loaded.
  */
 class FailMock extends CoreMock


### PR DESCRIPTION
This PR

* [x] fixes the spelling of **Xdebug**

💁‍♂ For reference, also see 

- https://twitter.com/derickr/status/1184465999971700736
- https://github.com/composer/composer/pull/8406