### PR TITLE
Updates for PHP and phpunit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 dist: trusty
-sudo: false
 
 git:
   depth: 5
@@ -10,23 +9,25 @@ cache:
     - $HOME/.composer/cache
     - vendor
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
-  - nightly
-
-matrix:
+jobs:
   include:
-    - dist: precise
-      php: 5.3
+    - php: 5.3
+      dist: precise
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+    - php: 7.4snapshot
   fast_finish: true
   allow_failures:
-    - php: nightly
+    - php: 7.4snapshot
+
+before_install:
+  # disable Xdebug if present
+  - phpenv config-rm xdebug.ini || echo "Xdebug not present"
 
 install:
   - composer install --no-interaction --no-progress --prefer-dist --ansi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ clone_depth: 5
 
 environment:
   # This sets the PHP version (from Chocolatey)
-  PHPCI_CHOCO_VERSION: 7.3.1
+  PHPCI_CHOCO_VERSION: 7.3.11
   PHPCI_CACHE: C:\tools\phpci
   PHPCI_PHP: C:\tools\phpci\php
   PHPCI_COMPOSER: C:\tools\phpci\composer

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
         "issues": "https://github.com/composer/xdebug-handler/issues"
     },
     "require": {
-        "php": "^5.3.2 || ^7.0",
+        "php": "^5.3.2 || ^7.0 || ^8.0",
         "psr/log": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 7"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
     >
     <testsuites>


### PR DESCRIPTION
Tested on phpunit 6 and 7. Not compatible with phpunit 8 because it
requires return type declarations for extended classes.