### PR TITLE
Fix empty ini handling

### DIFF
--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -333,7 +333,7 @@ class XdebugHandler
 
         foreach ($iniFiles as $file) {
             // Check for inaccessible ini files
-            if (!$data = @file_get_contents($file)) {
+            if (($data = @file_get_contents($file)) === false) {
                 $error = 'Unable to read ini: '.$file;
                 return false;
             }

--- a/tests/Helpers/IniHelper.php
+++ b/tests/Helpers/IniHelper.php
@@ -60,6 +60,7 @@ class IniHelper
             '',
             $this->scanDir.DIRECTORY_SEPARATOR.'scan-one.ini',
             $this->scanDir.DIRECTORY_SEPARATOR.'scan-two.ini',
+            $this->scanDir.DIRECTORY_SEPARATOR.'scan-empty.ini',
         );
 
         $this->setEnvironment();
@@ -71,6 +72,7 @@ class IniHelper
             $this->loadedIni,
             $this->scanDir.DIRECTORY_SEPARATOR.'scan-one.ini',
             $this->scanDir.DIRECTORY_SEPARATOR.'scan-two.ini',
+            $this->scanDir.DIRECTORY_SEPARATOR.'scan-empty.ini',
         );
 
         $this->setEnvironment();


### PR DESCRIPTION
When `XdebugHandler` comes across an empty ini file, it report a `Unable to read ini` error. This appears to be caused by loose type matching when calling [`file_get_contents`](https://www.php.net/manual/en/function.file-get-contents.php#refsect1-function.file-get-contents-returnvalues).

The result of this error, in particular, causes `composer` to not restart itself with `xdebug` disabled.