### PR TITLE
Ignore SIGINTs to let the restarted process handle them

### DIFF
--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -256,6 +256,12 @@ class XdebugHandler
      */
     private function doRestart($command)
     {
+        // ignore SIGINTs here so the child process can receive and handle them
+        if (function_exists('pcntl_async_signals') && function_exists('pcntl_signal')) {
+            pcntl_async_signals(true);
+            pcntl_signal(SIGINT, SIG_IGN);
+        }
+
         passthru($command, $exitCode);
         $this->notify(Status::INFO, 'Restarted process exited '.$exitCode);
 


### PR DESCRIPTION
Ran into this while trying to implement https://github.com/composer/composer/commit/a07f9ffba98fe5472a3004b56299ca99e22dc6c9 and going insane wondering why the signal handler was never called :) This commit fixes it.