### PR TITLE
Fix Exception if 'pcntl_signal' is disabled

### DIFF
--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -575,7 +575,7 @@ class XdebugHandler
      */
     private function tryEnableSignals()
     {
-        if (!function_exists('pcntl_async_signals')) {
+        if (!function_exists('pcntl_async_signals') || !function_exists('pcntl_signal')) {
             return;
         }
 


### PR DESCRIPTION
If function `pcntl_signal()` is disabled following exception is thrown when running `xdebug-handler`:  
`PHP Fatal error:  Uncaught ErrorException: pcntl_signal() has been disabled for security reasons`

This PR fixes the issue.