### PR TITLE
Travis-ci: added support for ppc64le & removed unsupported jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,44 @@ matrix:
     - dist: bionic
       php: nightly
       env: platform=ignore
+#Added power jobs
+    - dist: xenial
+      arch: ppc64le
+      php: 5.6
+    - dist: xenial
+      arch: ppc64le
+      php: 7.0
+    - dist: bionic
+      arch: ppc64le
+      php: 7.1
+    - dist: bionic
+      arch: ppc64le
+      php: 7.2
+    - dist: bionic
+      arch: ppc64le
+      php: 7.4
+    - dist: bionic
+      arch: ppc64le
+      php: nightly
+      env: platform=ignore
   fast_finish: true
   allow_failures:
     - php: nightly
-
+# Disable version 5.3, 5.4, 5.5, 7.3
+jobs: 
+  exclude:
+    - dist: precise
+      arch: ppc64le
+      php: 5.3
+    - dist: trusty
+      arch: ppc64le
+      php: 5.4
+    - dist: trusty
+      arch: ppc64le
+      php: 5.5
+    - dist: bionic
+      arch: ppc64le
+      php: 7.3
 before_install:
   # disable Xdebug if present
   - phpenv config-rm xdebug.ini || echo "Xdebug not present"


### PR DESCRIPTION
Hi,

I had added ppc64le(Linux on Power) architecture support on Travis-CI in the PR and looks like its been successfully added.

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Regards,
Devendra