### PR TITLE
Proc_open fall-back for passthru config check

### DIFF
--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -565,11 +565,12 @@ class XdebugHandler
      * Returns true if there are no known configuration issues
      *
      * @param string $info Set by method
+     * @return bool
      */
     private function checkConfiguration(&$info)
     {
-        if (false !== strpos(ini_get('disable_functions'), 'passthru')) {
-            $info = 'passthru function is disabled';
+        if (!function_exists('proc_open') && !function_exists('passthru')) {
+            $info = 'execution functions have been disabled (proc_open() or passthru() is needed)';
             return false;
         }
 


### PR DESCRIPTION
Since f748184f / 2a7c843 proc_open() if available is preferred over
passthru().

The configuration check would not recognize it thought. Minor. I think we
forget it back in November.

Ref: f748184fed8dce2a3d4f16bed2859bac0f506799
Ref: 2a7c84364bb48f4611af1f068333b4d1bbb47807