### PR TITLE
Add Windows CTRL event handling on PHP 7.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ A temporary ini file is created from the loaded (and scanned) ini files, with an
 From PHP 7.1 with the pcntl extension loaded, asynchronous signal handling is automatically enabled. `SIGINT` is set to `SIG_IGN` in the parent
 process and restored to `SIG_DFL` in the restarted process (if no other handler has been set).
 
+From PHP 7.4 on Windows, `CTRL+C` and `CTRL+BREAK` handling is ignored in the parent process and automatically enabled in the restarted process.
+
 ### Limitations
 There are a few things to be aware of when running inside a restarted process.
 


### PR DESCRIPTION
Windows console event handling can be problematic because CTRL+C signals
may be disabled and this is inherited by child processes. Also there is
no `pcntl_signal_get_handler` equivalent in Windows PHP, so it is
impossible to know if signals are enabled or if a handler has been
registered.

When creating a handler, `sapi_windows_set_ctrl_handler` automatically
enables CTRL+C signals in the current process (and by default any child
process). In order to enable and transfer CTRL handling to the restarted
process, we register a handler in the parent that doesn't do anything
resulting in any existing handler being overwritten and the suppression
of CTRL events.