### PR TITLE
Bypass shell when restarting in PHP 7.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Note that the [setMainScript()](#setmainscriptscript) and [setPersistent()](#set
 #### _restart($command)_
 An application can extend this to modify the temporary ini file, its location given in the `tmpIni` property. New settings can be safely appended to the end of the data, which is `PHP_EOL` terminated.
 
-Note that the `$command` parameter is the escaped command-line string that will be used for the new process and must be treated accordingly.
+The `$command` parameter is an array of unescaped command-line arguments that will be used for the new process.
 
 Remember to finish with `parent::restart($command)`.
 
@@ -275,7 +275,7 @@ class MyRestarter extends XdebugHandler
         return $isLoaded || $this->required;
     }
 
-    protected function restart($command)
+    protected function restart(array $command)
     {
         if ($this->required) {
             # Add required ini setting to tmpIni

--- a/tests/Mocks/CoreMock.php
+++ b/tests/Mocks/CoreMock.php
@@ -109,7 +109,7 @@ class CoreMock extends XdebugHandler
         return $prop->getValue($this);
     }
 
-    protected function restart($command)
+    protected function restart(array $command)
     {
         static::createAndCheck(false, $this, static::$settings);
     }

--- a/tests/Mocks/FailMock.php
+++ b/tests/Mocks/FailMock.php
@@ -17,7 +17,7 @@ namespace Composer\XdebugHandler\Mocks;
  */
 class FailMock extends CoreMock
 {
-    protected function restart($command)
+    protected function restart(array $command)
     {
         static::createAndCheck(true, $this, static::$settings);
     }

--- a/tests/Mocks/PartialMock.php
+++ b/tests/Mocks/PartialMock.php
@@ -31,7 +31,7 @@ class PartialMock extends CoreMock
         return $this->tmpIni;
     }
 
-    protected function restart($command)
+    protected function restart(array $command)
     {
         $this->command = $command;
         $this->restarted = true;

--- a/tests/RestartTest.php
+++ b/tests/RestartTest.php
@@ -34,13 +34,12 @@ class RestartTest extends BaseTestCase
 
         // Check command
         $xdebug = PartialMock::createAndCheck($loaded);
-        $command = $xdebug->getCommand();
-        $n = Process::escape('-n');
-        $c = Process::escape('-c');
-        $tmpIni = Process::escape($xdebug->getTmpIni());
+        $command = implode(' ', $xdebug->getCommand());
+        $tmpIni = $xdebug->getTmpIni();
 
-        $pattern = preg_quote(sprintf('%s %s %s', $n, $c, $tmpIni), '/');
-        $this->assertRegExp('/'.$pattern.'/', $command);
+        $pattern = preg_quote(sprintf(' -n -c %s ', $tmpIni), '/');
+        $matched = (bool) preg_match('/'.$pattern.'/', $command);
+        $this->assertTrue($matched);
     }
 
     public function testNoRestartWhenNotLoaded()
@@ -106,8 +105,7 @@ class RestartTest extends BaseTestCase
         $xdebug = PartialMock::createAndCheck($loaded, null, $settings);
         $command = $xdebug->getCommand();
 
-        $pattern = preg_quote(Process::escape($script), '/');
-        $this->assertRegExp('/'.$pattern.'/', $command);
+        $this->assertContains($script, $command);
     }
 
     public function scriptSetterProvider()
@@ -130,9 +128,7 @@ class RestartTest extends BaseTestCase
         $tmpIni = $xdebug->getTmpIni();
 
         foreach (array('-n', '-c', $tmpIni) as $param) {
-            $pattern = preg_quote(Process::escape($param), '/');
-            $matched = (bool) preg_match('/'.$pattern.'/', $command);
-            $this->assertFalse($matched);
+            $this->assertNotContains($param, $command);
         }
     }
 


### PR DESCRIPTION
In PHP-7.4 `proc_open` accepts an array of command-line options which are automatically quoted for the OS. This enables the shell to be bypassed and the php process to be called directly for the restart.

This feature is used if available, otherwise the command-line is quoted as before. Support for `passthru` has been dropped to make life simpler.

Note: This requires a version bump to 2.0