### PR TITLE
Don't typehint restart for 1.x compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ class MyRestarter extends XdebugHandler
         return $isLoaded || $this->required;
     }
 
-    protected function restart(array $command)
+    protected function restart($command)
     {
         if ($this->required) {
             # Add required ini setting to tmpIni

--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -239,9 +239,11 @@ class XdebugHandler
     /**
      * Allows an extending class to access the tmpIni
      *
+     * Do not typehint for 1.x compatibility
+     *
      * @param array $command
      */
-    protected function restart(array $command)
+    protected function restart($command)
     {
         $this->doRestart($command);
     }

--- a/tests/ClassTest.php
+++ b/tests/ClassTest.php
@@ -54,6 +54,29 @@ class ClassTest extends TestCase
         );
     }
 
+    /**
+     * Test compatibility with 1.x for extending classes
+     *
+     * @requires PHP 7.1
+     * @dataProvider methodProvider
+     */
+    public function testNoTypeHintingOnMethod($method)
+    {
+        $xdebug = new XdebugHandler('myapp');
+        $refMethod = new \ReflectionMethod($xdebug, $method);
+        $refParams = $refMethod->getParameters();
+
+        $this->assertCount(1, $refParams);
+        $this->assertNull($refParams[0]->getType());
+    }
+
+    public function methodProvider()
+    {
+        return array(
+            array('restart'),
+        );
+    }
+
     private function setException($exception)
     {
         if (!method_exists($this, 'expectException')) {

--- a/tests/Mocks/CoreMock.php
+++ b/tests/Mocks/CoreMock.php
@@ -109,7 +109,7 @@ class CoreMock extends XdebugHandler
         return $prop->getValue($this);
     }
 
-    protected function restart(array $command)
+    protected function restart($command)
     {
         static::createAndCheck(false, $this, static::$settings);
     }

--- a/tests/Mocks/FailMock.php
+++ b/tests/Mocks/FailMock.php
@@ -17,7 +17,7 @@ namespace Composer\XdebugHandler\Mocks;
  */
 class FailMock extends CoreMock
 {
-    protected function restart(array $command)
+    protected function restart($command)
     {
         static::createAndCheck(true, $this, static::$settings);
     }

--- a/tests/Mocks/PartialMock.php
+++ b/tests/Mocks/PartialMock.php
@@ -31,7 +31,7 @@ class PartialMock extends CoreMock
         return $this->tmpIni;
     }
 
-    protected function restart(array $command)
+    protected function restart($command)
     {
         $this->command = $command;
         $this->restarted = true;


### PR DESCRIPTION
Removes `array` typehint on protected `restart` method. This gives us the option to increase the minimum PHP for version 2 and not cause any pain for apps that extend this method and support older versions (in all dependents listed on Packagist they use this method to modify the tmp ini file, rather than modify the command).