### PR TITLE
Do not restart if xdebug mode is off

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,16 +119,8 @@ $version = XdebugHandler::getSkippedVersion();
 # $version: '2.6.0' (for example), or an empty string
 ```
 
-#### _isXdebugOff()_
-Returns true if Xdebug is running with `xdebug.mode=off`. Returns false if Xdebug is running in a different mode, if configuration modes are not supported, or if Xdebug is not loaded.
-
-```php
-use Composer\XdebugHandler\XdebugHandler;
-
-if (extension_loaded('xdebug') && !XdebugHandler::isXdebugOff()) {
-    # Code will take longer to run
-}
-```
+#### _isXdebugActive()_
+Returns true if Xdebug is loaded and is running in an active mode (if it supports modes). Returns false if Xdebug is not loaded, or it is running with `xdebug.mode=off`.
 
 ### Setter methods
 These methods implement a fluent interface and must be called before the main `check()` method.

--- a/src/Status.php
+++ b/src/Status.php
@@ -33,6 +33,7 @@ class Status
     private $envAllowXdebug;
     private $loaded;
     private $logger;
+    private $modeOff;
     private $time;
 
     /**
@@ -91,7 +92,12 @@ class Status
 
     private function reportCheck($loaded)
     {
-        $this->loaded = $loaded;
+        list($version, $mode) = explode('|', $loaded);
+
+        if ($version) {
+            $this->loaded = '('.$version.')'.($mode ? ' mode='.$mode : '');
+        }
+        $this->modeOff = $mode === 'off';
         $this->output('Checking '.$this->envAllowXdebug);
     }
 
@@ -112,7 +118,7 @@ class Status
         if ($this->loaded) {
             $text = sprintf('No restart (%s)', $this->getEnvAllow());
             if (!getenv($this->envAllowXdebug)) {
-                $text .= ' Allowed by application';
+                $text .= ' Allowed by '.($this->modeOff ? 'mode' : 'application');
             }
             $this->output($text);
         }
@@ -157,7 +163,7 @@ class Status
      */
     private function getLoadedMessage()
     {
-        $loaded = $this->loaded ? sprintf('loaded (%s)', $this->loaded) : 'not loaded';
+        $loaded = $this->loaded ? sprintf('loaded %s', $this->loaded) : 'not loaded';
         return 'The Xdebug extension is '.$loaded;
     }
 }

--- a/tests/ClassTest.php
+++ b/tests/ClassTest.php
@@ -73,6 +73,7 @@ class ClassTest extends TestCase
     public function methodProvider()
     {
         return array(
+            array('requiresRestart'),
             array('restart'),
         );
     }

--- a/tests/Mocks/CoreMock.php
+++ b/tests/Mocks/CoreMock.php
@@ -96,10 +96,10 @@ class CoreMock extends XdebugHandler
         $prop->setAccessible(true);
         $prop->setValue($this, $mode);
 
-        // Set private static xdebugOff
-        $prop = $this->refClass->getProperty('xdebugOff');
+        // Set private static xdebugActive
+        $prop = $this->refClass->getProperty('xdebugActive');
         $prop->setAccessible(true);
-        $prop->setValue($this, $mode === 'off');
+        $prop->setValue($this, $loaded && $mode !== 'off');
 
         // Ensure static private skipped is unset
         $prop = $this->refClass->getProperty('skipped');

--- a/tests/Mocks/CoreMock.php
+++ b/tests/Mocks/CoreMock.php
@@ -40,7 +40,17 @@ class CoreMock extends XdebugHandler
 
     public static function createAndCheck($loaded, $parentProcess = null, $settings = array())
     {
-        $xdebug = new static($loaded);
+        $mode = null;
+
+        if (is_array($loaded)) {
+            list($loaded, $mode) = $loaded;
+        }
+
+        if ($mode && !$loaded) {
+            throw new \InvalidArgumentException('Unexpected mode when not loaded: '.$mode);
+        }
+
+        $xdebug = new static($loaded, $mode);
 
         if ($parentProcess) {
             // This is a restart, so set restarted on parent so it is copied
@@ -69,7 +79,7 @@ class CoreMock extends XdebugHandler
         return $xdebug->childProcess ?: $xdebug;
     }
 
-    final public function __construct($loaded)
+    final public function __construct($loaded, $mode)
     {
         parent::__construct('mock');
 
@@ -80,6 +90,16 @@ class CoreMock extends XdebugHandler
         $prop = $this->refClass->getProperty('loaded');
         $prop->setAccessible(true);
         $prop->setValue($this, $this->parentLoaded);
+
+        // Set private mode
+        $prop = $this->refClass->getProperty('mode');
+        $prop->setAccessible(true);
+        $prop->setValue($this, $mode);
+
+        // Set private static xdebugOff
+        $prop = $this->refClass->getProperty('xdebugOff');
+        $prop->setAccessible(true);
+        $prop->setValue($this, $mode === 'off');
 
         // Ensure static private skipped is unset
         $prop = $this->refClass->getProperty('skipped');

--- a/tests/RestartTest.php
+++ b/tests/RestartTest.php
@@ -42,6 +42,15 @@ class RestartTest extends BaseTestCase
         $this->assertTrue($matched);
     }
 
+    public function testRestartWhenModeIsNotOff()
+    {
+        $loaded = array(true, 'debug,trace');
+
+        $xdebug = CoreMock::createAndCheck($loaded);
+        $this->checkRestart($xdebug);
+        $this->assertFalse($xdebug::isXdebugOff());
+    }
+
     public function testNoRestartWhenNotLoaded()
     {
         $loaded = false;
@@ -57,6 +66,15 @@ class RestartTest extends BaseTestCase
 
         $xdebug = CoreMock::createAndCheck($loaded);
         $this->checkNoRestart($xdebug);
+    }
+
+    public function testNoRestartWhenModeIsOff()
+    {
+        $loaded = array(true, 'off');
+
+        $xdebug = CoreMock::createAndCheck($loaded);
+        $this->checkNoRestart($xdebug);
+        $this->assertTrue($xdebug::isXdebugOff());
     }
 
     public function testFailedRestart()

--- a/tests/RestartTest.php
+++ b/tests/RestartTest.php
@@ -48,7 +48,7 @@ class RestartTest extends BaseTestCase
 
         $xdebug = CoreMock::createAndCheck($loaded);
         $this->checkRestart($xdebug);
-        $this->assertFalse($xdebug::isXdebugOff());
+        $this->assertFalse($xdebug::isXdebugActive());
     }
 
     public function testNoRestartWhenNotLoaded()
@@ -57,6 +57,7 @@ class RestartTest extends BaseTestCase
 
         $xdebug = CoreMock::createAndCheck($loaded);
         $this->checkNoRestart($xdebug);
+        $this->assertFalse($xdebug::isXdebugActive());
     }
 
     public function testNoRestartWhenLoadedAndAllowed()
@@ -66,6 +67,7 @@ class RestartTest extends BaseTestCase
 
         $xdebug = CoreMock::createAndCheck($loaded);
         $this->checkNoRestart($xdebug);
+        $this->assertTrue($xdebug::isXdebugActive());
     }
 
     public function testNoRestartWhenModeIsOff()
@@ -74,7 +76,7 @@ class RestartTest extends BaseTestCase
 
         $xdebug = CoreMock::createAndCheck($loaded);
         $this->checkNoRestart($xdebug);
-        $this->assertTrue($xdebug::isXdebugOff());
+        $this->assertFalse($xdebug::isXdebugActive());
     }
 
     public function testFailedRestart()


### PR DESCRIPTION
Xdebug3 introduces specific modes and mode `off` adds minimal overhead to the process. Mode discovery is best-attempt and will be solved when Xdebug provides a specific function.

A static helper function `isXdebugOff()` is provided to determine if Xdebug is loaded and running with xdebug.mode=off.