### PR TITLE
Open up Process class

### DIFF
--- a/src/PhpConfig.php
+++ b/src/PhpConfig.php
@@ -49,8 +49,8 @@ class PhpConfig
     public function usePersistent()
     {
         if ($data = $this->getDataAndReset()) {
-            Process::setEnv('PHPRC', $data['tmpIni']);
-            Process::setEnv('PHP_INI_SCAN_DIR', '');
+            $this->updateEnv('PHPRC', $data['tmpIni']);
+            $this->updateEnv('PHP_INI_SCAN_DIR', '');
         }
 
         return array();
@@ -64,10 +64,21 @@ class PhpConfig
     private function getDataAndReset()
     {
         if ($data = XdebugHandler::getRestartSettings()) {
-            Process::setEnv('PHPRC', $data['phprc']);
-            Process::setEnv('PHP_INI_SCAN_DIR', $data['scanDir']);
+            $this->updateEnv('PHPRC', $data['phprc']);
+            $this->updateEnv('PHP_INI_SCAN_DIR', $data['scanDir']);
         }
 
         return $data;
+    }
+
+    /**
+     * Updates a restart settings value in the environment
+     *
+     * @param string $name
+     * @param string|false $value
+     */
+    private function updateEnv($name, $value)
+    {
+        Process::setEnv($name, false !== $value ? $value : null);
     }
 }

--- a/src/Process.php
+++ b/src/Process.php
@@ -12,11 +12,9 @@
 namespace Composer\XdebugHandler;
 
 /**
- * Provides utility functions to prepare a child process command-line and set
- * environment variables in that process.
+ * Process utility functions
  *
  * @author John Stevenson <john-stevenson@blueyonder.co.uk>
- * @internal
  */
 class Process
 {
@@ -64,16 +62,33 @@ class Process
     }
 
     /**
+     * Escapes an array of arguments that make up a shell command
+     *
+     * @param array $args Argument list, with the module name first
+     *
+     * @return string The escaped command line
+     */
+    public static function escapeShellCommand(array $args)
+    {
+        $cmd = self::escape(array_shift($args), true, true);
+        foreach ($args as $arg) {
+            $cmd .= ' '.self::escape($arg);
+        }
+
+        return $cmd;
+    }
+
+    /**
      * Makes putenv environment changes available in $_SERVER and $_ENV
      *
      * @param string $name
-     * @param string|false $value A false value unsets the variable
+     * @param string|null $value A null value unsets the variable
      *
      * @return bool Whether the environment variable was set
      */
-    public static function setEnv($name, $value = false)
+    public static function setEnv($name, $value = null)
     {
-        $unset = false === $value;
+        $unset = null === $value;
 
         if (!putenv($unset ? $name : $name.'='.$value)) {
             return false;

--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -288,10 +288,7 @@ class XdebugHandler
         if (PHP_VERSION_ID >= 70400) {
             $cmd = $command;
         } else {
-            $cmd = Process::escape(array_shift($command), true, true);
-            foreach ($command as $arg) {
-                $cmd .= ' '.Process::escape($arg);
-            }
+            $cmd = Process::escapeShellCommand($command);
             if (defined('PHP_WINDOWS_VERSION_BUILD')) {
                 // Outer quotes required on cmd string below PHP 8
                 $cmd = '"'.$cmd.'"';

--- a/tests/IniFilesTest.php
+++ b/tests/IniFilesTest.php
@@ -141,7 +141,7 @@ class IniFilesTest extends BaseTestCase
         $xdebug = CoreMock::createAndCheck($loaded);
 
         // We need to remove the mock inis from the environment
-        Process::setEnv(CoreMock::ORIGINAL_INIS, false);
+        Process::setEnv(CoreMock::ORIGINAL_INIS, null);
         $this->checkNoRestart($xdebug);
     }
 


### PR DESCRIPTION
Removes @internal annotation to make utility methods safely available. They are already being copied or used by some implementations.