### PR TITLE
Fix phpstan when using simple-phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         }
     },
     "scripts": {
-        "test": "SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT=1 vendor/bin/simple-phpunit",
+        "test": "vendor/bin/simple-phpunit",
         "phpstan": "vendor/bin/phpstan analyse"
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,7 @@
 parameters:
     level: 5
+    bootstrapFiles:
+        - tests/bootstrap_phpstan.php
     paths:
         - src
         - tests

--- a/tests/bootstrap_phpstan.php
+++ b/tests/bootstrap_phpstan.php
@@ -1,0 +1,13 @@
+<?php
+
+$vendorBin = __DIR__.'/../vendor/bin';
+$path = $vendorBin.'/simple-phpunit';
+
+if (!file_exists($vendorBin.'/phpunit') && file_exists($path)) {
+    passthru(escapeshellarg(realpath($path)).' install');
+
+    $autoloader = $vendorBin.'/.phpunit/phpunit/vendor/autoload.php';
+    if (file_exists($autoloader)) {
+        require $autoloader;
+    }
+}


### PR DESCRIPTION
PHPStan cannot find PHPUnit classes when simple-phpunit is being used because they are not in the autoloader. This fix ensures that PHPUnit is installed in `vendor/bin/.phpunit` and autoloads the classes. 

It uses the `vendor/bin/.phpunit/phpunit` directory that simple-phpunit creates with a symlink from the installed phpunit folder. However this won't work on Windows, where you (generally) need to be an admin to create symlinks: https://github.com/symfony/symfony/pull/40754