### PR TITLE
Do not restart with cmd.exe if cwd is a UNC path

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -64,4 +64,7 @@ jobs:
         run: composer update ${{ env.COMPOSER_FLAGS }}
 
       - name: Run tests
+        # Temp fix. PHP 8.1 needs phpunit 9.5.5+
+        env:
+          SYMFONY_DEPRECATIONS_HELPER: disabled=1
         run: vendor/bin/simple-phpunit --verbose

--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -598,6 +598,15 @@ class XdebugHandler
             }
         }
 
+
+        $workingDir = getcwd();
+        if (0 === strpos($workingDir, '\\\\')) {
+            if (defined('PHP_WINDOWS_VERSION_BUILD') && PHP_VERSION_ID < 70400) {
+                $info = 'cmd.exe does not support UNC paths: '.$workingDir;
+                return false;
+            }
+        }
+
         return true;
     }
 


### PR DESCRIPTION
cmd.exe does not support a UNC path as the working directory and will change it to the Windows directory before executing any command. We bypass cmd.exe on PHP 7.4+ by calling the php binary directly so this only affects earlier versions.

See: https://github.com/composer/composer/issues/9858