### PR TITLE
Use xdebug_info to get mode in Xdebug-3.1

### DIFF
--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -66,7 +66,11 @@ class XdebugHandler
         if (extension_loaded('xdebug')) {
             $this->loaded = phpversion('xdebug') ?: 'unknown';
 
-            if (false !== ($mode = ini_get('xdebug.mode'))) {
+            if (version_compare($this->loaded, '3.1', '>=')) {
+                /** @phpstan-ignore-next-line */
+                $modes = xdebug_info('mode');
+                $this->mode = empty($modes) ? 'off' : implode(',', $modes);
+            } elseif (false !== ($mode = ini_get('xdebug.mode'))) {
                 $this->mode = getenv('XDEBUG_MODE') ?: ($mode  ?: 'off');
                 if (preg_match('/^,+$/', str_replace(' ', '', $this->mode))) {
                     $this->mode = 'off';


### PR DESCRIPTION
As per: https://github.com/xdebug/xdebug/commit/c6ebf3105eb287231bb9d0b913951c1017958f1f

Xdebug 3.1 scheduled release date: 2021-06-30
