### PR TITLE
Allow `psr/log` 2 and 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": "^5.3.2 || ^7.0 || ^8.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1 || ^2 || ^3"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.2 || ^5",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,3 +5,5 @@ parameters:
     paths:
         - src
         - tests
+    excludePaths:
+        - tests/Helpers/LegacyLogger.php

--- a/tests/ClassTest.php
+++ b/tests/ClassTest.php
@@ -11,6 +11,7 @@
 
 namespace Composer\XdebugHandler;
 
+use Composer\XdebugHandler\Helpers\LegacyLogger;
 use Composer\XdebugHandler\Helpers\Logger;
 use PHPUnit\Framework\TestCase;
 
@@ -48,7 +49,7 @@ class ClassTest extends TestCase
     {
         // $setter, $value
         return array(
-            'setLogger' => array('setLogger', new Logger()),
+            'setLogger' => array('setLogger', \PHP_VERSION_ID < 70100 ? new LegacyLogger() : new Logger()),
             'setMainScript' => array('setMainScript', '--'),
             'setPersistent' => array('setPersistent', null),
         );

--- a/tests/Helpers/LegacyLogger.php
+++ b/tests/Helpers/LegacyLogger.php
@@ -13,11 +13,11 @@ namespace Composer\XdebugHandler\Helpers;
 
 use Psr\Log\AbstractLogger;
 
-class Logger extends AbstractLogger
+class LegacyLogger extends AbstractLogger
 {
     protected $output = array();
 
-    public function log($level, $message, array $context = array()): void
+    public function log($level, $message, array $context = array())
     {
         $this->output[] = array($level, $message, $context);
     }

--- a/tests/StatusTest.php
+++ b/tests/StatusTest.php
@@ -12,6 +12,7 @@
 namespace Composer\XdebugHandler;
 
 use Composer\XdebugHandler\Helpers\BaseTestCase;
+use Composer\XdebugHandler\Helpers\LegacyLogger;
 use Composer\XdebugHandler\Helpers\Logger;
 use Composer\XdebugHandler\Mocks\CoreMock;
 use Psr\Log\LogLevel;
@@ -27,7 +28,7 @@ class StatusTest extends BaseTestCase
     {
         $loaded = true;
 
-        $logger = new Logger();
+        $logger = \PHP_VERSION_ID < 70100 ? new LegacyLogger() : new Logger();
         $settings = array('setLogger' => array($logger));
 
         $xdebug = CoreMock::createAndCheck($loaded, null, $settings);


### PR DESCRIPTION
This PR proposes to indicate compatibility with version 2 and 3 of the `psr/log` package.

~~Version 3 is blocked by the `Composer\XdebugHandler\Helpers\Logger` class. We would need to add a `void` return type to the `log` method, but we cannot do this as long as the package maintains compatibility with PHP 5, unfortunately.~~

I've created two versions of the `Composer\XdebugHandler\Helpers\Logger` class which seems to be used for tests only. This way, we can even test against `psr/log` 3.