### PR TITLE
Updates for phpstan level 7

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 6
+    level: 7
     bootstrapFiles:
         - tests/bootstrap_phpstan.php
     paths:


### PR DESCRIPTION
Note that the removal of the version check (>= 5.3.6) for `DEBUG_BACKTRACE_IGNORE_ARGS` is safe, because we have already bailed on PHP < 5.4.