### PR TITLE
Updates for phpstan level 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     },
     "require": {
         "php": "^5.3.2 || ^7.0 || ^8.0",
-        "psr/log": "^1 || ^2 || ^3"
+        "psr/log": "^1 || ^2 || ^3",
+        "composer/pcre": "^1"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.2 || ^5.0 || ^6.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 7
+    level: 9
     bootstrapFiles:
         - tests/bootstrap_phpstan.php
     paths:

--- a/src/Process.php
+++ b/src/Process.php
@@ -11,6 +11,8 @@
 
 namespace Composer\XdebugHandler;
 
+use Composer\Pcre\Preg;
+
 /**
  * Process utility functions
  *
@@ -38,10 +40,10 @@ class Process
 
         $quote = strpbrk($arg, " \t") !== false || $arg === '';
 
-        $arg = preg_replace('/(\\\\*)"/', '$1$1\\"', $arg, -1, $dquotes);
+        $arg = Preg::replace('/(\\\\*)"/', '$1$1\\"', $arg, -1, $dquotes);
 
         if ($meta) {
-            $meta = $dquotes || preg_match('/%[^%]+%/', $arg);
+            $meta = $dquotes || Preg::isMatch('/%[^%]+%/', $arg);
 
             if (!$meta) {
                 $quote = $quote || strpbrk($arg, '^&|<>()') !== false;
@@ -51,11 +53,11 @@ class Process
         }
 
         if ($quote) {
-            $arg = '"'.preg_replace('/(\\\\*)$/', '$1$1', $arg).'"';
+            $arg = '"'.(Preg::replace('/(\\\\*)$/', '$1$1', $arg)).'"';
         }
 
         if ($meta) {
-            $arg = preg_replace('/(["^&|<>()%])/', '^$1', $arg);
+            $arg = Preg::replace('/(["^&|<>()%])/', '^$1', $arg);
         }
 
         return $arg;

--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -11,6 +11,7 @@
 
 namespace Composer\XdebugHandler;
 
+use Composer\Pcre\Preg;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -96,7 +97,7 @@ class XdebugHandler
                 $this->mode = empty($modes) ? 'off' : implode(',', $modes);
             } elseif (false !== ($mode = ini_get('xdebug.mode'))) {
                 $this->mode = getenv('XDEBUG_MODE') ?: ($mode  ?: 'off');
-                if (preg_match('/^,+$/', str_replace(' ', '', $this->mode))) {
+                if (Preg::isMatch('/^,+$/', str_replace(' ', '', $this->mode))) {
                     $this->mode = 'off';
                 }
             }
@@ -346,7 +347,7 @@ class XdebugHandler
         if ($this->debug === '2') {
             $this->notify(Status::INFO, 'Temp ini saved: '.$this->tmpIni);
         } else {
-            @unlink($this->tmpIni);
+            @unlink((string) $this->tmpIni);
         }
 
         exit($exitCode);
@@ -423,10 +424,10 @@ class XdebugHandler
                 return false;
             }
             // Check and remove directives after HOST and PATH sections
-            if (preg_match($sectionRegex, $data, $matches, PREG_OFFSET_CAPTURE)) {
+            if (Preg::isMatchWithOffsets($sectionRegex, $data, $matches, PREG_OFFSET_CAPTURE)) {
                 $data = substr($data, 0, $matches[0][1]);
             }
-            $content .= preg_replace($xdebugRegex, ';$1', $data).PHP_EOL;
+            $content .= Preg::replace($xdebugRegex, ';$1', $data).PHP_EOL;
         }
 
         // Merge loaded settings into our ini content, if it is valid

--- a/tests/IniFilesTest.php
+++ b/tests/IniFilesTest.php
@@ -11,6 +11,7 @@
 
 namespace Composer\XdebugHandler\Tests;
 
+use Composer\Pcre\Preg;
 use Composer\XdebugHandler\Process;
 use Composer\XdebugHandler\Tests\Helpers\BaseTestCase;
 use Composer\XdebugHandler\Tests\Helpers\IniHelper;
@@ -73,12 +74,12 @@ class IniFilesTest extends BaseTestCase
 
         $content = $this->getTmpIniContent($xdebug);
         $regex = '/^\s*;zend_extension\s*=.*xdebug.*$/mi';
-        $result = preg_match_all($regex, $content);
+        $result = Preg::matchAll($regex, $content);
         $this->assertSame($result, $matches);
 
         // Check content is end-of-line terminated
         $regex = sprintf('/%s/', preg_quote(PHP_EOL));
-        $this->assertTrue((bool) preg_match($regex, $content));
+        $this->assertTrue(Preg::isMatch($regex, $content));
     }
 
     public function tmpIniProvider()

--- a/tests/RestartTest.php
+++ b/tests/RestartTest.php
@@ -11,6 +11,7 @@
 
 namespace Composer\XdebugHandler\Tests;
 
+use Composer\Pcre\Preg;
 use Composer\XdebugHandler\Tests\Helpers\BaseTestCase;
 use Composer\XdebugHandler\Tests\Mocks\CoreMock;
 use Composer\XdebugHandler\Tests\Mocks\FailMock;
@@ -38,7 +39,7 @@ class RestartTest extends BaseTestCase
         $tmpIni = $xdebug->getTmpIni();
 
         $pattern = preg_quote(sprintf(' -n -c %s ', $tmpIni), '/');
-        $matched = (bool) preg_match('/'.$pattern.'/', $command);
+        $matched = Preg::isMatch('/'.$pattern.'/', $command);
         $this->assertTrue($matched);
     }
 


### PR DESCRIPTION
Above level 7 phpstan gives us:

```
 ------ -----------------------------------------------------------------------------------------------
  Line   src\Process.php
 ------ -----------------------------------------------------------------------------------------------
  44     Parameter #2 $subject of function preg_match expects string, string|null given.
  47     Parameter #1 $string of function strpbrk expects string, string|null given.
  54     Parameter #3 $subject of function preg_replace expects array|string, string|null given.
  58     Parameter #3 $subject of function preg_replace expects array|string, string|null given.
  61     Method Composer\XdebugHandler\Process::escape() should return string but returns string|null.
 ------ -----------------------------------------------------------------------------------------------

 ------ ------------------------------------------------------------------------------
  Line   src\XdebugHandler.php
 ------ ------------------------------------------------------------------------------
  349    Parameter #1 $filename of function unlink expects string, string|null given.
 ------ ------------------------------------------------------------------------------
 [ERROR] Found 6 errors
```

which this PR fixes by adding suitable `(string)` casts - which sort of feels a bit wrong.
