### PR TITLE
Fix isXdebugActive if used before class instantiation

### DIFF
--- a/tests/Helpers/BaseTestCase.php
+++ b/tests/Helpers/BaseTestCase.php
@@ -142,7 +142,7 @@ abstract class BaseTestCase extends TestCase
         self::assertSame(true, isset($_SERVER[CoreMock::ORIGINAL_INIS]));
 
         // Skipped version must only be reported if it was unloaded in the restart
-        if (!$xdebug->parentLoaded) {
+        if ($xdebug->parentXdebugVersion === null) {
             // Mocked successful restart without Xdebug
             $version = '';
         } elseif ($xdebug instanceof FailMock) {

--- a/tests/Mocks/CoreMock.php
+++ b/tests/Mocks/CoreMock.php
@@ -35,8 +35,8 @@ class CoreMock extends XdebugHandler
     /** @var bool */
     public $restarted;
 
-    /** @var bool */
-    public $parentLoaded;
+    /** @var string|null */
+    public $parentXdebugVersion;
 
     /** @var null|static */
     protected $childProcess;
@@ -80,7 +80,7 @@ class CoreMock extends XdebugHandler
             // properties on the parent and child
             $parentProcess->restarted = true;
             $xdebug->restarted = true;
-            $xdebug->parentLoaded = $parentProcess->parentLoaded;
+            $xdebug->parentXdebugVersion = $parentProcess->parentXdebugVersion;
 
             // Make the child available
             $parentProcess->childProcess = $xdebug;
@@ -109,15 +109,15 @@ class CoreMock extends XdebugHandler
         parent::__construct('mock');
 
         $this->refClass = new \ReflectionClass('Composer\XdebugHandler\XdebugHandler');
-        $this->parentLoaded = $loaded ? static::TEST_VERSION : null;
+        $this->parentXdebugVersion = $loaded ? static::TEST_VERSION : null;
 
-        // Set private loaded
-        $prop = $this->refClass->getProperty('loaded');
+        // Set private static xdebugVersion
+        $prop = $this->refClass->getProperty('xdebugVersion');
         $prop->setAccessible(true);
-        $prop->setValue($this, $this->parentLoaded);
+        $prop->setValue($this, $this->parentXdebugVersion);
 
-        // Set private mode
-        $prop = $this->refClass->getProperty('mode');
+        // Set private static xdebugMode
+        $prop = $this->refClass->getProperty('xdebugMode');
         $prop->setAccessible(true);
         $prop->setValue($this, $mode);
 
@@ -128,11 +128,6 @@ class CoreMock extends XdebugHandler
 
         // Ensure static private skipped is unset
         $prop = $this->refClass->getProperty('skipped');
-        $prop->setAccessible(true);
-        $prop->setValue($this, null);
-
-        // Ensure static private inRestart is unset
-        $prop = $this->refClass->getProperty('inRestart');
         $prop->setAccessible(true);
         $prop->setValue($this, null);
 

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -86,7 +86,7 @@ class SettingsTest extends BaseTestCase
         putenv(CoreMock::ORIGINAL_INIS);
         unset($_SERVER[CoreMock::ORIGINAL_INIS]);
 
-        // Mock not loaded ($inRestart and $skipped statics are unset)
+        // Mock not loaded (static $skipped is unset in mock constructor)
         $loaded = false;
         CoreMock::createAndCheck($loaded);
 


### PR DESCRIPTION
Reported here  https://github.com/composer/composer/pull/10416
