### PR TITLE
Adapt to recent version of PHPUnit (10)

### DIFF
--- a/tests/IniFilesTest.php
+++ b/tests/IniFilesTest.php
@@ -158,7 +158,7 @@ class IniFilesTest extends BaseTestCase
     /**
      * Tests that directives below HOST and PATH sections are removed
      *
-     * @dataProvider iniSectionsProvider      *
+     * @dataProvider iniSectionsProvider
      */
     public function testIniSections(string $sectionName): void
     {

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -28,7 +28,7 @@ class SettingsTest extends BaseTestCase
      * @param string $iniFunc IniHelper method to use
      * @param false|string $scanDir Initial value for PHP_INI_SCAN_DIR
      * @param false|string $phprc Initial value for PHPRC
-     * @dataProvider environmentProvider     *
+     * @dataProvider environmentProvider
      */
     public function testGetRestartSettings(string $iniFunc, $scanDir, $phprc): void
     {


### PR DESCRIPTION
Hi,

Without this typo fix, latest versions of phpunit error out with a code 2.

phpunit
PHPUnit 10.1.3 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.2.5
Configuration: /build/php-composer-xdebug-handler-3.0.3/phpunit.xml.dist

...................................................               51 / 51 (100%)

Time: 00:00.076, Memory: 8.00 MB

There were 2 PHPUnit errors:

1) Composer\XdebugHandler\Tests\IniFilesTest::testIniSections
The data provider specified for Composer\XdebugHandler\Tests\IniFilesTest::testIniSections is invalid
Method Composer\XdebugHandler\Tests\IniFilesTest::iniSectionsProvider      *() does not exist

/build/php-composer-xdebug-handler-3.0.3/tests/IniFilesTest.php:163

2) Composer\XdebugHandler\Tests\SettingsTest::testGetRestartSettings
The data provider specified for Composer\XdebugHandler\Tests\SettingsTest::testGetRestartSettings is invalid
Method Composer\XdebugHandler\Tests\SettingsTest::environmentProvider     *() does not exist

/build/php-composer-xdebug-handler-3.0.3/tests/SettingsTest.php:33

--

There was 1 PHPUnit test runner deprecation:

1) Your XML configuration validates against a deprecated schema. Migrate your XML configuration using "--migrate-configuration"!

OK, but there are issues!
Tests: 51, Assertions: 264, Deprecations: 1.
