### PR TITLE
Support php binary path with whitespaces

### DIFF
--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -410,7 +410,7 @@ class XdebugHandler
      */
     private function getCommand(): array
     {
-        $php = [PHP_BINARY];
+        $php = [\escapeshellarg(PHP_BINARY)];
         $args = array_slice($_SERVER['argv'], 1);
 
         if (!$this->persistent) {


### PR DESCRIPTION
I am using Laravel Herd for my local PHP environment. That means, that my PHP binary is located in `/Users/jkrzefski/Library/Application Support/Herd/bin/php82`. As you can see, there is a whitespace in the path.

When the XdebugHandler attempts to restart the command, the path to the binary must be escaped, because otherwise I get the following error message:

```
sh: /Users/jkrzefski/Library/Application: No such file or directory
```