### PR TITLE
Detect crash signals in restarted process exit code

### DIFF
--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -299,7 +299,19 @@ class XdebugHandler
 
         $process = proc_open($cmd, [], $pipes);
         if (is_resource($process)) {
+            // Use proc_get_status to reliably detect signal deaths, because
+            // proc_close returns the raw signal number on non-Windows, making
+            // it indistinguishable from a normal exit code (php/php-src#21292).
+            $status = proc_get_status($process);
             $exitCode = proc_close($process);
+
+            if (!$status['running'] && $status['signaled']) {
+                $exitCode = 128 + $status['termsig'];
+                $this->notify(Status::ERROR, sprintf(
+                    'Restarted process was killed by signal %d',
+                    $status['termsig']
+                ));
+            }
         }
 
         if (!isset($exitCode)) {
@@ -316,34 +328,8 @@ class XdebugHandler
             @unlink((string) $this->tmpIni);
         }
 
-        // On non-Windows, proc_close returns the raw signal number when the
-        // child process is killed by a signal, making it indistinguishable
-        // from a normal exit code. Detect common crash signals and normalize
-        // the exit code to the Unix convention of 128 + signal number.
-        if (!defined('PHP_WINDOWS_VERSION_BUILD') && isset(self::CRASH_SIGNALS[$exitCode])) {
-            $signal = self::CRASH_SIGNALS[$exitCode];
-            $this->notify(Status::ERROR, sprintf(
-                'Restarted process crashed with %s (signal %d)',
-                $signal,
-                $exitCode
-            ));
-            $exitCode = 128 + $exitCode;
-        }
-
         exit($exitCode);
     }
-
-    /**
-     * Signal names for common crash signals returned by proc_close()
-     *
-     * @var array<int, string>
-     */
-    private const CRASH_SIGNALS = [
-        4 => 'SIGILL',
-        6 => 'SIGABRT',
-        8 => 'SIGFPE',
-        11 => 'SIGSEGV',
-    ];
 
     /**
      * Returns the command line array if everything was written for the restart

--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -299,19 +299,28 @@ class XdebugHandler
 
         $process = proc_open($cmd, [], $pipes);
         if (is_resource($process)) {
-            // Use proc_get_status to reliably detect signal deaths, because
-            // proc_close returns the raw signal number on non-Windows, making
-            // it indistinguishable from a normal exit code (php/php-src#21292).
+            // Poll proc_get_status until the process exits, so we can
+            // reliably read the signaled/termsig fields. We can't use
+            // proc_close alone because it returns the raw signal number
+            // on non-Windows, indistinguishable from a normal exit code.
+            // See https://github.com/php/php-src/issues/21292
             $status = proc_get_status($process);
-            $exitCode = proc_close($process);
+            while ($status['running']) {
+                usleep(100_000);
+                $status = proc_get_status($process);
+            }
 
-            if (!$status['running'] && $status['signaled']) {
+            if ($status['signaled']) {
                 $exitCode = 128 + $status['termsig'];
                 $this->notify(Status::ERROR, sprintf(
                     'Restarted process was killed by signal %d',
                     $status['termsig']
                 ));
+            } else {
+                $exitCode = $status['exitcode'];
             }
+
+            proc_close($process);
         }
 
         if (!isset($exitCode)) {

--- a/src/XdebugHandler.php
+++ b/src/XdebugHandler.php
@@ -316,8 +316,34 @@ class XdebugHandler
             @unlink((string) $this->tmpIni);
         }
 
+        // On non-Windows, proc_close returns the raw signal number when the
+        // child process is killed by a signal, making it indistinguishable
+        // from a normal exit code. Detect common crash signals and normalize
+        // the exit code to the Unix convention of 128 + signal number.
+        if (!defined('PHP_WINDOWS_VERSION_BUILD') && isset(self::CRASH_SIGNALS[$exitCode])) {
+            $signal = self::CRASH_SIGNALS[$exitCode];
+            $this->notify(Status::ERROR, sprintf(
+                'Restarted process crashed with %s (signal %d)',
+                $signal,
+                $exitCode
+            ));
+            $exitCode = 128 + $exitCode;
+        }
+
         exit($exitCode);
     }
+
+    /**
+     * Signal names for common crash signals returned by proc_close()
+     *
+     * @var array<int, string>
+     */
+    private const CRASH_SIGNALS = [
+        4 => 'SIGILL',
+        6 => 'SIGABRT',
+        8 => 'SIGFPE',
+        11 => 'SIGSEGV',
+    ];
 
     /**
      * Returns the command line array if everything was written for the restart


### PR DESCRIPTION
## Summary

On non-Windows systems, `proc_close()` returns the raw signal number when the child process is killed by a signal (e.g. **11** for `SIGSEGV`). This is indistinguishable from a normal exit code, causing consumers to silently exit with a misleading code and no diagnostic output.

This PR uses `proc_get_status()` — which provides definitive `signaled` and `termsig` fields — to reliably detect when the child process was killed by a signal, then normalizes the exit code to the Unix convention of `128 + signal`.

### Why proc_get_status() instead of guessing

The previous approach hardcoded known signal numbers (4, 6, 8, 11) and assumed those exit codes meant a signal death. But those are also valid normal exit codes — `exit(11)` would be misidentified as SIGSEGV.

`proc_get_status()` returns separate `signaled` (bool) and `termsig` (int) fields that definitively distinguish signal deaths from normal exits. This works on all PHP versions and handles any signal.

Also filed php/php-src#21293 to fix `proc_close()` itself, but that would only help on future PHP versions.

### Context

Discovered while investigating [vimeo/psalm#11679](https://github.com/vimeo/psalm/issues/11679), where Psalm's restarted process crashes with `SIGSEGV` due to a PHP JIT bug, but `proc_close()` returns `11` — silently producing a misleading exit code.

### Before

```
$ psalm --no-cache
No errors found!
$ echo $?
11
# No indication of what went wrong
```

### After

```
$ XDEBUG_HANDLER_DEBUG=1 psalm --no-cache
No errors found!
xdebug-handler[1234] Restarted process was killed by signal 11
$ echo $?
139
```